### PR TITLE
Fix syntax error in plans.mdx

### DIFF
--- a/get-started/plans-old.mdx
+++ b/get-started/plans-old.mdx
@@ -1,0 +1,171 @@
+---
+title: "Plans and credits"
+sidebarTitle: "Plans and credits"
+description: "Understand different plans at Relevance AI, and learn how to manage your subscription"
+---
+
+## Understanding credits
+
+Relevance provides a variety of plans enabling you to choose the best option according to your needs.
+
+Each plan supports a certain number of users, credits per execution, specific data size and certain Large Language Models.
+
+Below is a brief overview of the available plans and their specification.
+
+For the most updated list, please visit Relevance AI's [pricing](https://relevanceai.com/pricing) page.
+
+<Note>
+  It is always possible to upgrade or downgrade your plan based on your usage and workload\!
+</Note>
+
+### Base credits costs
+
+The base cost for running any tool or agent is 4 credits. However, this cost varies depending on your plan.
+
+| Plan       | Credits per run |
+| ---------- | --------------- |
+| Free       | 4               |
+| Pro        | 4               |
+| Team       | 3               |
+| Business   | 2               |
+| Enterprise | 2               |
+
+### How many credits do I have left?
+
+<img
+  src="/images/credit-counter-explanation.png"
+  alt="Image showing the credits counter in Relevance AI, and explaining that the counter shows the number of credits remaining over the number of credits in your plan per month / year"
+  className="mx-auto"
+/>
+
+You can view how many credits you have left in the bottom left of Relevance AI. The credits counter will show you a total of the **number of credits you have left remaining** over the **number of credits you receive in your plan per month / year** (or day if you're a free user).
+
+The color of the counter also indicates how many credits you have remaining based on how many you have in your billing period. If your counter is green, this means you're in a good position\! If the counter turns red, you should consider adding more credits if you think you're going to run out before your next renewal, or consider upgrading to a higher plan in the future.
+
+For example, in the image above, this user is on a Team plan, billed monthly. They currently receive 100,000 credits per month, and have 75,500 left. They have 14 days left, and are in a good position to continue using Relevance AI until their next renewal period.
+
+### What affects total credit cost?
+
+Your total credit consumption depends on several factors:
+
+#### Tool steps
+
+- When using integrations without your own API key, additional credits are charged since you're using our API keys.
+- If you provide your own API key, no additional credits are charged for integrations.
+
+#### Large Language Model selection
+
+- Different models have different credit costs.
+- Specific costs can be found in the `model` selector within the platform.
+
+<Frame>
+  ![](/images/model-selector.png)
+</Frame>
+
+#### Knowledge sync
+
+- Knowledge is our RAG (Retrieval-Augmented Generation) solution that enables you to provide additional context to your agents and tools.
+- When syncing knowledge, yourdata is vectorized to enable search capabilities.
+- Knowledge sync operations have the same base credit cost as a tool run.
+
+### Credit allocation and reset
+
+#### Reset schedule
+
+- **Free Plan:** Credits reset daily at midnight, Sydney time (AEST / AEDT)
+- **Paid Plans:** Credits reset at your next renewal date
+
+### Purchasing additional credits
+
+If you have a paid plan, you can purchase extra credits to use before your next renewal if you run out.
+
+If you purchase these extra credits, **please note that these do not roll over to the next billing cycle**. You will sacrifice your credits at your next renewal date, and your credits will reset to your plan's default amount.
+
+The minimum amount of credits you can purchase is 10000 credits (\$20 USD).
+
+### Monitoring credit usage
+
+#### At an Organization level
+
+To check your credit consumption at an Organization level:
+
+1. Click 'Settings' in the sidebar
+2. Navigate to Plan & Billing
+
+<Warning>
+  You'll only have access to this section if you are an admin of your Organization.
+</Warning>
+
+![Marketing image for plan and billing](/images/credits_plan_billing.png)
+
+From this page, you will be able to see credit usage across your entire Organization, and view this by Agent or see a detailed view of your credit expenses.
+
+#### At an individual Agent level
+
+You can also see how many credits your Agent used, broken down by each Tool and your Agent's LLM cost. 
+
+<div style={{ width:"100%",position:"relative",paddingTop:"56.25%" }}>
+<iframe src="https://app.supademo.com/embed/cmdy9kmsa8eo39f96j64ckfzb" frameBorder="0" title="How to view the credit usage of an Agent run" allow="clipboard-write" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style={{ position:"absolute",top:0,left:0,width:"100%",height:"100%",border:"3px solid #5E43CE",borderRadius:"10px" }} />
+</div>
+
+1. First, access the run of your Agent you want to view credits on, on the Run screen
+2. Click the number next to 'Credits used'
+3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
+
+## Paying for plans
+
+At this time, we only offer the ability to pay for subscriptions using a credit card. We do not support debit cards at this time.
+
+## Cancelling your subscription
+
+You can cancel your Relevance AI subscription at any time by following this tutorial:
+
+<div style={{ width:"100%",position:"relative",paddingTop:"56.25%" }}>
+<iframe src="https://app.supademo.com/embed/cmaypwh9o8hb9ho3rmx2lo1j6" frameBorder="0" title="How to cancel your subscription in Relevance AI" allow="clipboard-write" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style={{ position:"absolute",top:0,left:0,width:"100%",height:"100%",border:"3px solid #5E43CE",borderRadius:"10px" }} />
+
+</div>
+
+1. To start, click the 'Manage plan' section at the bottom of the platform while logged into Relevance AI
+2. Click on 'Cancel subscription'
+3. On the pop-up that opens, click 'Cancel subscription' _again_ to make sure the cancellation goes through
+4. You should then be directed to a pop-up confirming that you've cancelled successfully
+
+If the platform doesn't confirm that you've cancelled successfully, please try again, then **contact support** to ensure that your cancellation has gone through and you will not be billed.
+
+If the platform has confirmed your cancellation is successful, you do not need to reach out to our support team.
+
+Once you cancel, you'll still have access to your upgraded features until your next renewal date. You will not have your subscription immediately cancelled, and your latest payment will not be refunded. If you have any further questions about cancellation, please [reach out to our support team](https://relevanceai.com/docs/get-started/support).
+
+## Invoices and receipts
+
+Invoices and receipts for payment will be sent to the user at your company who purchased the subscription / credits at the time of purchase. You'll also be sent a receipt / invoice at every renewal.
+
+However, if you need to get a new invoice / receipt, or find invoices / receipts in the platform, please follow these steps:
+
+<div style={{ width:"100%",position:"relative",paddingTop:"56.25%" }}>
+<iframe src="https://app.supademo.com/embed/cmayxs0dm8m6qho3rskl47udq" frameBorder="0" title="How to grab your invoices and receipts from Relevance AI" allow="clipboard-write" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style={{ position:"absolute",top:0,left:0,width:"100%",height:"100%",border:"3px solid #5E43CE",borderRadius:"10px" }} />
+
+</div>
+
+1. Click 'Settings' while logged into Relevance AI
+2. Click 'Plan & billing'
+3. Under 'Payment', click 'View details'
+4. This will open our payment system's page. On this page, scroll down to 'Invoice History' and click the payment you want to get an invoice for
+5. On the page that opens, click 'Download invoice' or 'Download receipt' based on the document you need
+
+If you need to change the name of your company on your invoice / receipt, please [reach out to our support team](https://relevanceai.com/docs/get-started/support). The easiest way to do this would be to forward your latest invoice to [support@relevanceai.com](mailto:support@relevanceai.com).
+
+## Frequently asked questions (FAQs)
+
+<AccordionGroup>
+  <Accordion title="I've accidentally upgraded with annual billing, but I meant to upgrade with monthly billing. How do I change to monthly billing going forward?">
+    Unfortunately if you change in platform, this change will only be put into place at your next renewal date in a year.
+
+    If you want to change to monthly billing immediately, you'll need to [reach out to our support team](https://relevanceai.com/docs/get-started/support).
+  </Accordion>
+  <Accordion title="I've just renewed but it's showing that I've already used all of my credits?">
+    Check your credit counter to make sure you've read this correctly. Your credits counter will show you **the number of credits you have left to use**, not the number of credits you've used.
+
+    If your counter is showing 10100 credits over 10000, for instance, this means you have 10100 credits left to use in your current billing period, not that you've used 10100 credits. 
+  </Accordion>
+</AccordionGroup>

--- a/get-started/plans.mdx
+++ b/get-started/plans.mdx
@@ -106,6 +106,7 @@ You can also see how many credits your Agent used, broken down by each Tool and 
 
 <div style={{ width:"100%",position:"relative",paddingTop:"56.25%" }}>
 <iframe src="https://app.supademo.com/embed/cmdy9kmsa8eo39f96j64ckfzb" frameBorder="0" title="How to view the credit usage of an Agent run" allow="clipboard-write" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style={{ position:"absolute",top:0,left:0,width:"100%",height:"100%",border:"3px solid #5E43CE",borderRadius:"10px" }} />
+</div>
 
 1. First, access the run of your Agent you want to view credits on, on the Run screen
 2. Click the number next to 'Credits used'


### PR DESCRIPTION
Fixed missing closing div tag that was causing a linter error in get-started/plans.mdx. The div element wrapping the iframe on line 107 was missing its closing tag, which has now been added.