### PR TITLE
Add three new FAQs and remove redundant FAQ (TSP-569)

### DIFF
--- a/integrations/popular-integrations/slack.mdx
+++ b/integrations/popular-integrations/slack.mdx
@@ -206,8 +206,16 @@ This will disconnect your Slack workspace from Relevance AI, and your agents wil
     If you want to be able to send a message to a specific person in Slack, that person will first need to send a message to the Relevance AI bot in Slack. Once they do this, their name will appear as a destination option when sending Slack messages.
   </Accordion>
   
-  <Accordion title="How do I trigger my Workforce via Slack?">
-    Follow the steps under section **Triggering Agents or Workforce from Slack**. The process is the same as setting up an Agent trigger, but you'll select your Workforce instead of an individual Agent. Learn more about [Workforce Triggers](/workforce/build-an-ai-workforce/add-triggers).
+  <Accordion title="Slack isn't working as intended, how do I fix it?">
+    The most common reason Slack isn't working as expected is that your integration needs to be updated. We occasionally release improvements to our Slack app, and older installations don't pick these up automatically. Updating only takes a moment - go to your project's integrations page, find your Slack connection and click 'Reconnect'.
+  </Accordion>
+  
+  <Accordion title="When I setup a Slack trigger, I can't find channels in my workspace.">
+    This usually happens for one of two reasons. First, the email address you use in Slack may not match the email you used when signing up to Relevance - we require these to be the same. Second, the Relevance AI app might not have been invited to the channel yet. To fix this, open the channel and run `/invite @RelevanceAI`, and it should appear.
+  </Accordion>
+  
+  <Accordion title="What's the easiest way to install the Relevance AI Slack App?">
+    The easiest and most reliable method is to install Slack directly through Relevance. Start the Slack integration connection flow in Relevance and a request will automatically be sent to your Slack admin for approval. In some cases, admins install the Relevance AI app in Slack before the integration is set up in Relevance, which can create sync issues. Installing via Relevance avoids this.
   </Accordion>
   
   <Accordion title="Can I see what my Agent is doing when triggered from Slack?">


### PR DESCRIPTION
- Added FAQ: 'Slack isn't working as intended, how do I fix it?'
- Added FAQ: 'When I setup a Slack trigger, I can't find channels in my workspace.'
- Added FAQ: 'What's the easiest way to install the Relevance AI Slack App?'
- Removed redundant FAQ 'How do I trigger my Workforce via Slack?' that just redirected to existing section