### PR TITLE
Update invoices and receipts section in plans documentation

### DIFF
--- a/get-started/subscriptions/plans.mdx
+++ b/get-started/subscriptions/plans.mdx
@@ -115,11 +115,19 @@ description: "Understand different plans at Relevance AI, and learn how to manag
 
     ## Invoices and receipts
 
-    Your invoices and receipts will be sent to your billing contact. This is the person who purchased the subscription originally. These invoices and receipts will be sent every renewal to this person. 
+    Invoices and receipts for payment will be sent to the user at your company who purchased the subscription / credits at the time of purchase. You'll also be sent a receipt / invoice at every renewal.
 
-    If another member of your organization needs to view invoices and receipts, please forward them onto these team members via email.
+    To find your invoices and receipts in the platform:
 
-    <Warning>We currently do not have the ability to self-serve invoices and receipts in platform, but hope to add this functionality soon. If you have any questions, please [reach out to our support team](https://relevanceai.com/docs/get-started/support).</Warning>
+    1. Click 'Settings' while logged into Relevance AI
+    2. Click 'Invoice management'
+    3. From here, you can view and download your invoices and receipts
+
+    <Warning>
+      You'll only have access to Invoice management if you are an admin of your Organization.
+    </Warning>
+
+    If you need to change the name of your company on your invoice / receipt, please [reach out to our support team](https://relevanceai.com/docs/get-started/support). The easiest way to do this would be to forward your latest invoice to [support@relevanceai.com](mailto:support@relevanceai.com).
 
     ## Frequently asked questions (FAQs)
     


### PR DESCRIPTION
- Clarified the process for receiving invoices and receipts, specifying that they are sent to the user who purchased the subscription.
- Added step-by-step instructions for accessing invoices and receipts in the platform.
- Included a warning about access limitations to invoice management for non-admin users.
- Provided guidance on how to change the company name on invoices/receipts.