### PR TITLE
Remove Advanced Knowledge Search from docs.json navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -285,7 +285,6 @@
                       "tool/tool-steps/knowledge/delete-knowledge",
                       "tool/tool-steps/knowledge/update-knowledge",
                       "tool/tool-steps/knowledge/advanced-knowledge-search-2m",
-                      "tool/tool-steps/knowledge/advanced-knowledge-search",
                       "tool/tool-steps/knowledge/knowledge-search",
                       "tool/tool-steps/knowledge/get-knowledge",
                       "tool/tool-steps/knowledge/using-variables-in-json"


### PR DESCRIPTION
Remove the 'Advanced Knowledge Search' page from the docs.json navigation/page tree. The original Advanced Knowledge Search tool was hidden from the UI in PR #7555 (August 2025), so the documentation page should no longer appear in navigation.

Requirements:

Remove 'tool/tool-steps/knowledge/advanced-knowledge-search' from the docs.json Knowledge Tool steps section

Do NOT delete the actual page file ([advanced-knowledge-search.md](http://advanced-knowledge-search.md/)) - keep it accessible for existing links

Consider adding a deprecation notice on the page itself directing users to 'Advanced Knowledge Search (2M Context)'

Context:
The original RAG-based 'Advanced Knowledge Search' tool was hidden from the UI and replaced with 'Advanced Knowledge Search (2M Context)' which uses CAG-based retrieval. The documentation should reflect this change by removing the old page from navigation.