### PR TITLE
Add generate-review-pdf Claude Code skill

### DIFF
--- a/.claude/skills/generate-review-pdf/SKILL.md
+++ b/.claude/skills/generate-review-pdf/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: generate-review-pdf
+description: Generate a PDF of a documentation page for external teams to review before shipping
+disable-model-invocation: true
+argument-hint: "[path-to-mdx-file]"
+---
+
+# Generate review PDF
+
+Convert a documentation `.mdx` page into a clean, styled PDF for external review (e.g. product managers, stakeholders). The PDF is saved to `~/Downloads/`.
+
+## Input
+
+`$ARGUMENTS` should be the path to an `.mdx` file (relative or absolute). If not provided, ask the user which page to convert.
+
+## Steps
+
+1. **Read the `.mdx` file** to get the full page content.
+
+2. **Generate an HTML file** in `/tmp/` that faithfully renders the page content with clean styling. Use the template structure from [template.html](template.html) as the base.
+
+3. **Content conversion rules** — convert MDX components to their HTML equivalents:
+
+   | MDX Component | HTML Equivalent |
+   |---------------|-----------------|
+   | `<Warning>` | Yellow callout box with "WARNING" label |
+   | `<Note>` | Blue callout box with "NOTE" label |
+   | `<Tip>` | Green callout box with "TIP" label |
+   | `<Info>` | Blue callout box with "INFO" label |
+   | `<Columns>` + `<Card>` | CSS grid of styled card boxes |
+   | `<AccordionGroup>` + `<Accordion>` | **Fully expanded** FAQ items — show question as header, answer as body. Accordions don't work in PDFs so all content must be visible. |
+   | `<Steps>` + `<Step>` | Numbered list with step titles as bold headings |
+   | `<Tabs>` + `<Tab>` | Show all tabs expanded with tab title as heading |
+   | Supademo `<iframe>` | **Cannot embed in PDF.** Replace with a styled clickable link box pointing to the Supademo URL. Convert the embed URL from `/embed/[ID]` to `/demo/[ID]` for the link. Label it "Interactive Walkthrough (Supademo)" with the iframe's `title` attribute as the link text. |
+   | `<CardGroup>` | CSS grid of linked card boxes |
+   | Markdown headings, lists, bold, links | Standard HTML equivalents |
+
+4. **Add a review banner** at the top of the PDF with:
+   - "Documentation Review Draft" label
+   - Current date
+   - The file path / destination URL if known
+   - Current git branch name
+
+5. **Convert HTML to PDF** using Chrome headless:
+   ```bash
+   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --print-to-pdf="$OUTPUT_PATH" "$HTML_PATH"
+   ```
+
+6. **Clean up** the temporary HTML file.
+
+7. **Tell the user** the output path.
+
+## Output filename
+
+Derive the PDF name from the MDX filename:
+- `user-level-authentication.mdx` → `User-Level-Authentication-Review.pdf`
+- `quick-start-guide.mdx` → `Quick-Start-Guide-Review.pdf`
+
+Save to `~/Downloads/`.
+
+## Styling guidelines
+
+- Use system fonts (`-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, ...`)
+- Max width 800px, centered
+- Purple accent color `#5E43CE` for Supademo link borders (matches the docs brand)
+- Cards: light grey background `#f8f8fc`, subtle border
+- Callouts: coloured left border with tinted background
+- FAQs: bordered boxes with grey header background, fully expanded
+- Add `page-break-inside: avoid` on cards, callouts, and FAQ items
+- Add `print-color-adjust: exact` for print media

--- a/.claude/skills/generate-review-pdf/template.html
+++ b/.claude/skills/generate-review-pdf/template.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{TITLE}} - Documentation Review</title>
+<style>
+  @page { margin: 1in 0.75in; size: A4; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; color: #1a1a2e; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 40px 24px; }
+  h1 { font-size: 28px; font-weight: 700; margin-bottom: 8px; color: #0f0f1a; }
+  h2 { font-size: 20px; font-weight: 600; margin-top: 32px; margin-bottom: 12px; color: #0f0f1a; border-bottom: 2px solid #e8e8f0; padding-bottom: 6px; }
+  h3 { font-size: 16px; font-weight: 600; margin-top: 20px; margin-bottom: 8px; color: #1a1a2e; }
+  p { margin-bottom: 12px; font-size: 14px; }
+  ul, ol { margin-bottom: 12px; padding-left: 24px; font-size: 14px; }
+  li { margin-bottom: 4px; }
+  strong { font-weight: 600; }
+  a { color: #5E43CE; }
+
+  .subtitle { font-size: 15px; color: #555; margin-bottom: 24px; }
+  .review-banner { background: #f0edff; border: 1px solid #5E43CE; border-radius: 8px; padding: 12px 16px; margin-bottom: 24px; font-size: 13px; color: #3b2d8e; }
+  .review-banner strong { color: #5E43CE; }
+
+  /* Callouts: Warning, Note, Tip, Info */
+  .callout { border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; font-size: 13px; }
+  .callout-warning { background: #fff8e6; border-left: 4px solid #f0a500; }
+  .callout-note { background: #e8f4f8; border-left: 4px solid #0284c7; }
+  .callout-tip { background: #ecfdf5; border-left: 4px solid #10b981; }
+  .callout-info { background: #e8f4f8; border-left: 4px solid #0284c7; }
+  .callout-label { font-weight: 700; text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; margin-bottom: 4px; }
+  .callout-warning .callout-label { color: #b87a00; }
+  .callout-note .callout-label { color: #0369a1; }
+  .callout-tip .callout-label { color: #059669; }
+  .callout-info .callout-label { color: #0369a1; }
+
+  /* Card grids */
+  .card-grid { display: grid; gap: 12px; margin-bottom: 16px; }
+  .card-grid-2 { grid-template-columns: 1fr 1fr; }
+  .card-grid-3 { grid-template-columns: 1fr 1fr 1fr; }
+  .card { background: #f8f8fc; border: 1px solid #e2e2ea; border-radius: 8px; padding: 14px; page-break-inside: avoid; }
+  .card-title { font-weight: 600; font-size: 13px; margin-bottom: 4px; color: #1a1a2e; }
+  .card-body { font-size: 13px; color: #444; }
+
+  /* Supademo links (replaces iframes) */
+  .supademo-link { display: block; background: #f5f3ff; border: 2px solid #5E43CE; border-radius: 10px; padding: 20px; text-align: center; margin-bottom: 16px; text-decoration: none; color: #5E43CE; font-weight: 600; font-size: 14px; page-break-inside: avoid; }
+  .supademo-link .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: #7c6bc4; margin-bottom: 4px; display: block; font-weight: 400; }
+
+  /* FAQ items (expanded accordions) */
+  .faq-section { margin-top: 16px; }
+  .faq-item { border: 1px solid #e2e2ea; border-radius: 8px; margin-bottom: 8px; page-break-inside: avoid; }
+  .faq-q { font-weight: 600; font-size: 14px; padding: 12px 16px; background: #f8f8fc; border-radius: 8px 8px 0 0; color: #1a1a2e; }
+  .faq-a { font-size: 13px; padding: 12px 16px; color: #333; }
+  .faq-a ul { margin-top: 6px; margin-bottom: 0; }
+
+  /* Print styles */
+  @media print {
+    body { padding: 0; }
+    .supademo-link, .card, .callout, .faq-item { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  }
+</style>
+</head>
+<body>
+
+<!-- Review banner -->
+<div class="review-banner">
+  <strong>Documentation Review Draft</strong> &mdash; {{BRANCH}} &bull; {{DATE}}<br>
+  Page path: <strong>{{PAGE_PATH}}</strong>
+</div>
+
+<!-- Page title from frontmatter -->
+<h1>{{TITLE}}</h1>
+<p class="subtitle">{{DESCRIPTION}}</p>
+
+<!--
+  CONTENT GOES HERE
+
+  Replace MDX components with their HTML equivalents per the rules in SKILL.md.
+  Below are example snippets for each component type.
+-->
+
+<!-- Example: Callout (Warning) -->
+<!--
+<div class="callout callout-warning">
+  <div class="callout-label">Warning</div>
+  Callout content here.
+</div>
+-->
+
+<!-- Example: Card grid -->
+<!--
+<div class="card-grid card-grid-2">
+  <div class="card"><div class="card-title">Title</div><div class="card-body">Description</div></div>
+  <div class="card"><div class="card-title">Title</div><div class="card-body">Description</div></div>
+</div>
+-->
+
+<!-- Example: Supademo link (replacing iframe) -->
+<!--
+<a class="supademo-link" href="https://app.supademo.com/demo/DEMO_ID" target="_blank">
+  <span class="label">Interactive Walkthrough (Supademo)</span>
+  Demo title from iframe title attribute &rarr;
+</a>
+-->
+
+<!-- Example: FAQ (expanded accordion) -->
+<!--
+<div class="faq-section">
+  <div class="faq-item">
+    <div class="faq-q">Question text from Accordion title</div>
+    <div class="faq-a">Answer content, fully visible.</div>
+  </div>
+</div>
+-->
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill (`/generate-review-pdf`) that converts `.mdx` documentation pages into styled PDFs for external review
- Includes an HTML template with styling for callouts, cards, FAQs, and Supademo links
- Handles components that don't work in PDFs: Supademos become clickable links, accordions are fully expanded

## Test plan
- [ ] Run `/generate-review-pdf` with any `.mdx` page and verify PDF output in `~/Downloads/`
- [ ] Confirm Supademo links are clickable and point to correct demo URLs
- [ ] Confirm all FAQ content is visible (not collapsed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)