### PR TITLE
Add non-blocking afdocs CI check

### DIFF
--- a/.github/workflows/afdocs.yml
+++ b/.github/workflows/afdocs.yml
@@ -1,0 +1,15 @@
+name: Agent-Friendly Docs Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  afdocs:
+    name: afdocs check
+    runs-on: ubuntu-latest
+    # Continue even if the check fails — this is informational only
+    continue-on-error: true
+    steps:
+      - name: Run afdocs checks
+        run: npx afdocs@latest check https://docs.relevanceai.com --format text --verbose


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs [afdocs](https://www.npmjs.com/package/afdocs) checks against docs.relevanceai.com on PRs to main
- Uses `continue-on-error: true` so the check is informational only and won't block merging
- Tests 21 agent-friendly documentation checks across 8 categories (llms.txt, markdown availability, page size, content structure, URL stability, etc.)

## Test plan
- [x] Ran `npx afdocs check` locally — 8 passed, 3 warnings, 3 failed, 7 skipped
- [x] Verify the workflow runs on this PR's check suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)