### PR TITLE
Add migration context to streaming events docs

### DIFF
--- a/get-started/enterprise/streaming-events.mdx
+++ b/get-started/enterprise/streaming-events.mdx
@@ -8,7 +8,7 @@ Stream audit logs and execution traces to your own infrastructure for compliance
 
 ## Overview
 
-Relevance AI delivers events in [**OpenTelemetry (OTEL)**](https://opentelemetry.io/) format—an open, vendor-neutral standard for telemetry data. This provides several advantages:
+Relevance AI delivers events in [**OpenTelemetry (OTEL)**](https://opentelemetry.io/) format - an open, vendor-neutral standard for telemetry data. This provides several advantages:
 
 - **Interoperability**: OTEL is supported by most major observability platforms, making it easy to route data to your existing tools
 - **Future-proof**: As an [industry standard backed by CNCF](https://www.cncf.io/projects/opentelemetry/), OTEL ensures your data pipelines won't be locked into proprietary formats
@@ -315,7 +315,7 @@ Resource attributes identify the service producing telemetry data. These attribu
 |-----------|------|-------|-------------|
 | `service.name` | string | `"Relevance AI"` | Logical name of the service producing telemetry |
 
-Resource attributes follow OpenTelemetry semantic conventions and help observability platforms group and filter telemetry by service.
+This attribute is applied to all spans - `chat`, `invoke_agent`, `multi_agent_system_trigger`, and `condition_trigger`. In your observability tool, you can filter all Relevance activity with a single query like `service.name = "Relevance AI"`, cleanly separating Relevance spans from your own services.
 
 **Example structure:**
 ```json
@@ -390,13 +390,15 @@ Records a complete agent conversation/invocation.
 | `relevance_ai.agent.knowledge_used` | array | Yes | Knowledge set IDs used |
 | `relevance_ai.agent.escalation.reason` | string | No | Escalation reason |
 | `relevance_ai.agent.escalation.context` | string | No | Escalation context |
-| `relevance_ai.agent.version_id` | string | No | The active version ID of the agent |
+| `relevance_ai.agent.version_id` | string | No | The active version ID of the agent at invocation time. Use this to compare performance across agent versions |
 
 ### `chat`
 
 Records a single LLM inference call.
 
 **Name**: `chat {model_name}`
+
+<Warning>This span was previously named `llm_completion`. If you have existing dashboards or queries filtering on `gen_ai.operation.name = "llm_completion"` or span names containing `llm_completion`, update them to use `"chat"`. The rename aligns with the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).</Warning>
 
 | Attribute | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -406,13 +408,17 @@ Records a single LLM inference call.
 | `gen_ai.request.max_tokens` | int | No | Max tokens setting |
 | `gen_ai.system_instructions` | string | No | System prompt |
 | `gen_ai.input.messages` | string | Yes | JSON-stringified input messages |
-| `gen_ai.tool.definitions` | string | Yes | JSON-stringified tool definitions |
+| `gen_ai.tool.definitions` | string | Yes | JSON-stringified tool definitions (use `JSON.parse()` to access as structured data) |
 | `gen_ai.response.id` | string | Yes | Provider's response ID |
 | `gen_ai.response.model` | string | Yes | Actual model used |
 | `gen_ai.response.finish_reasons` | array | Yes | Finish reasons (e.g., `["stop"]`) |
 | `gen_ai.output.messages` | string | Yes | JSON-stringified output messages |
 | `gen_ai.usage.input_tokens` | int | Yes | Input tokens used |
 | `gen_ai.usage.output_tokens` | int | Yes | Output tokens generated |
+
+**Attribute**: `gen_ai.tool.definitions`
+
+<Warning>`gen_ai.tool.definitions` was previously an array type (`arrayValue`). It is now a JSON string (`stringValue`). If you consume this field in your pipeline or queries, you need to call `JSON.parse()` on the value to work with the tool definitions as structured data. The content is identical - the same tool definitions are present, just serialized as a string for better compatibility across OTEL exporters and backends.</Warning>
 
 ### `multi_agent_system_trigger`
 
@@ -428,7 +434,7 @@ Records a complete workforce execution.
 | `relevance_ai.workforce.type` | string | Yes | `"chat"` or `"default"` |
 | `relevance_ai.workforce.metadata` | object | Yes | Custom metadata |
 | `relevance_ai.workforce.status` | string | Yes | Final status |
-| `relevance_ai.workforce.version_id` | string | No | The active version ID of the workforce |
+| `relevance_ai.workforce.version_id` | string | No | The active version ID of the workforce at trigger time. Use this to compare performance across workforce versions |
 
 ### `condition_trigger`
 


### PR DESCRIPTION
## Summary
- Added inline warnings for breaking changes: `llm_completion` renamed to `chat`, and `gen_ai.tool.definitions` changed from array to JSON string
- Enhanced `service.name` resource attribute description with practical filtering guidance
- Added version comparison context to `relevance_ai.agent.version_id` and `relevance_ai.workforce.version_id` attributes
- Fixed em dashes and British spelling per docs_dont.md

## Test plan
- [ ] Preview streaming events page at `/get-started/enterprise/streaming-events`
- [ ] Verify Warning callouts render correctly under `chat` span and after attributes table
- [ ] Confirm all links work (OpenTelemetry GenAI semantic conventions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)