### PR TITLE
fix(vibe-checks): allow claude[bot] to trigger workflow

### DIFF
--- a/.github/workflows/vibe-check.yml
+++ b/.github/workflows/vibe-check.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: "claude[bot]"
           claude_args: '--allowedTools "Read,Write,Glob,Grep,Bash(git diff:*),Bash(git fetch:*)"'
           prompt: |
             You are doing a vibe check on a documentation PR for the Relevance AI docs site.


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: "claude[bot]"` to the `claude-code-action` step in the vibe check workflow
- Fixes the workflow failing when a bot-opened PR (e.g. from the docs drafter) triggers the vibe check — the action's built-in bot guard was blocking it

## Test plan

- [ ] Merge a bot-opened PR and confirm the vibe check runs instead of erroring with "non-human actor" 

🤖 Generated with [Claude Code](https://claude.com/claude-code)