### PR TITLE
fix(vibe-checks): remove shallow fetch that broke merge base lookup

### DIFF
--- a/.github/workflows/vibe-check.yml
+++ b/.github/workflows/vibe-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get changed files
         id: changed
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.base_ref }}
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           git diff --name-only origin/${{ github.base_ref }}...HEAD >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Removes `--depth=1` from the `git fetch` step in the Vibe Checks workflow
- The shallow re-fetch was overwriting the full git history already fetched by `actions/checkout` (`fetch-depth: 0`), causing `git diff origin/main...HEAD` to fail with `fatal: no merge base` (exit 128)
- The cascading EOF error in `$GITHUB_OUTPUT` was a result of `git diff` never completing

## Test plan

- [ ] Open a test PR with `.mdx` changes and verify the Vibe Checks workflow completes without the merge base error
- [ ] Verify the PR comment is posted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)