### PR TITLE
docs(rbac): consolidated RBAC fixes and transition guide

### DIFF
--- a/admin/project-management/add-members.mdx
+++ b/admin/project-management/add-members.mdx
@@ -5,7 +5,7 @@ description: "Add members to your project to collaborate with your team."
 ---
 
 <Info>
-This page covers adding members to projects and organizations. If you're on an Enterprise subscription and want to learn about Role-Based Access Controls (RBAC) with more granular permissions, see our [RBAC documentation](https://relevanceai.com/docs/enterprise/rbac).
+This page describes the standard permission system used by organizations that have not yet migrated to RBAC. If your organization has RBAC enabled, see [Role-based access controls (RBAC)](/enterprise/rbac) for the current permission model and the [transition guide](/enterprise/rbac#transitioning-to-rbac) for what changes during migration.
 </Info>
 
 ## Add members to your project
@@ -21,7 +21,7 @@ This page covers adding members to projects and organizations. If you're on an E
 
 ### User roles
 
-Members in your organization can be assigned the following roles: Admin, Editor and Viewer. These roles determine what they can do inside of the platform, and what they can do when using the API.
+Members in your organization can be assigned the following roles: Admin, Editor, Chat, and Viewer. These roles determine what they can do inside of the platform, and what they can do when using the API.
 
 <AccordionGroup>
   <Accordion title="Admin" icon="user-tie-hair-long" iconType="duotone">
@@ -45,18 +45,17 @@ Members in your organization can be assigned the following roles: Admin, Editor 
 
     - Can run agents and tools.
   </Accordion>
+  <Accordion title="Chat" icon="message" iconType="duotone">
+    Access [Relevance Chat](/get-started/chat/introduction) only — cannot access the web app. Requires asset-level permissions to run specific agents.
+  </Accordion>
   <Accordion title="Viewer" icon="book-open-reader" iconType="duotone">
-    **Has read permissions for:**
-
-    - All datasets
-    - All knowledge sets
-    - All agents
-
-    **Other permissions:**
-
-    - Can run agents.
+    View agents, tools, and knowledge outputs only. Cannot run agents, create assets, or edit anything.
   </Accordion>
 </AccordionGroup>
+
+<Info>
+For comprehensive permission details including enterprise RBAC controls, see [Role-based access controls](/enterprise/rbac).
+</Info>
 
 ### Cancel pending invitations
 

--- a/enterprise/rbac.mdx
+++ b/enterprise/rbac.mdx
@@ -93,6 +93,10 @@ Project admins will be able to set a users role upon invite. Organization admins
 | **Chat**   | Access [Relevance Chat](/get-started/chat/introduction) only - cannot access the web app. Requires asset-level permissions to run agents. |
 | **Viewer** | View agents, tools, and knowledge outputs only, cannot run or edit anything                |
 
+<Info>
+Editor is a project-level role only and does not exist at organization or asset levels. Project Editors automatically have Admin permissions on all assets within the project.
+</Info>
+
 ### Permissions
 
 <Tip>
@@ -113,6 +117,9 @@ Scroll horizontally to view all columns, including the Chat role permissions.
 | Access Web App                         | ✅         | ✅          | ✅          | ✅          | ❌        |
 | Run a chat (LLM)                       | ✅         | ✅          | ✅          | ✅          | ✅        |
 
+<Info>
+Project Viewer access grants read-only visibility to full asset configurations — including prompts, tools, and steps. There is no field-level redaction. If a Viewer cannot see an agent's internals, it's because they lack asset-level access entirely, not because their read access is limited to metadata.
+</Info>
 
 ### Chat Role Details
 
@@ -180,6 +187,10 @@ Upon asset creation, the creator becomes the admin. An asset can have multiple a
 | View asset outputs              | ✅         | ✅          | ✅          |
 | View asset audit logs           | ✅         | ✅          | ✅          |
 
+<Info>
+Asset Viewer access grants read-only visibility to full asset configurations — including prompts, tools, and steps. There is no field-level redaction. If a Viewer cannot see an agent's internals, it's because they lack asset-level access entirely, not because their read access is limited to metadata.
+</Info>
+
 ----
 
 ## Workforce Permissions
@@ -208,6 +219,91 @@ This means when sharing a workforce, you must:
 <Tip>
 Learn more about [sharing workforces](/build/workforces/share-your-workforce) as cloneable templates.
 </Tip>
+
+----
+
+## Transitioning to RBAC
+
+If your organization is being migrated from legacy permissions to RBAC, this section covers what changes, what stays the same, and what actions you need to take.
+
+### Before RBAC (legacy permissions)
+
+The legacy permission system had three roles — Admin, Editor, and Viewer — applied at the project and organization level only:
+
+- **Admin** — full read and write access to all assets and settings
+- **Editor** — read and write access to all datasets, knowledge sets, and agents; could run agents and tools
+- **Viewer** — read access to all datasets, knowledge sets, and agents; could run agents
+
+There was no asset-level granularity. All users with a given role had the same access to every asset in the project by default. Shared credentials (API keys, OAuths) applied project-wide.
+
+### During the migration
+
+The Relevance AI team handles the technical migration to RBAC. You do not need to manually migrate roles, but you should review and adjust assignments after migration is complete.
+
+**How legacy roles map to RBAC roles by default:**
+
+| Legacy role | Default RBAC role (project level) |
+|-------------|-----------------------------------|
+| Admin       | Admin                             |
+| Editor      | Editor                            |
+| Viewer      | Viewer                            |
+
+<Warning>
+  The Viewer role changes significantly under RBAC. Legacy Viewers could run agents — RBAC Viewers cannot run anything and can only view assets they have been explicitly granted access to. Users who only need to interact with agents via chat should be assigned the Chat role, not Viewer.
+</Warning>
+
+After migration, review every user mapped to Viewer and determine whether they should be:
+- **Chat** — for users who only need to use agents through [Relevance Chat](/get-started/chat/introduction)
+- **Viewer** — for users who genuinely only need read access to asset configurations and outputs
+- **Member** — for users who need to run agents
+
+### After RBAC is enabled
+
+Once RBAC is active for your organization:
+
+- **Asset-level permissions are enforced.** Access to individual agents, tools, and knowledge bases is controlled separately from project-level roles.
+- **Project Editors and Admins retain full access** to all assets in that project automatically — project Admin and Editor roles cascade to asset Admin on all assets in the project.
+- **Members, Viewers, and Chat users need explicit asset-level permissions.** Without a grant, they will receive a 403 error when attempting to access an asset.
+- **Shared credentials can be scoped per tool.** Rather than all project members sharing one set of credentials, asset admins can assign specific authentication accounts per tool.
+- **Permissions are assigned via the Share modal** on each individual agent, tool, or knowledge base.
+
+### Action items for admins
+
+After RBAC is enabled, complete these steps to restore appropriate access for your team:
+
+- **Review user roles immediately.** Check that the default role mappings match your intended access levels, particularly for legacy Viewer accounts.
+- **Assign asset-level permissions** using the Share modal on each agent, tool, and knowledge base that non-Admin/Editor users need to access.
+- **Use RBAC Groups for bulk assignment.** If many users need the same access, create a group and assign asset permissions to the group rather than individual users.
+- **Audit chat-only users.** Confirm that users who only need [Relevance Chat](/get-started/chat/introduction) access are assigned the Chat project role, not Viewer.
+- **Verify critical users can access required assets.** Test access for key team members, especially those with Member or Viewer roles, before announcing the migration is complete.
+
+----
+
+## Permission inheritance and cascading
+
+Permissions cascade automatically from project level to assets within that project:
+
+| Project role | Automatic asset access |
+| ------------ | ---------------------- |
+| **Admin**    | Admin on all assets    |
+| **Editor**   | Admin on all assets    |
+| **Viewer**   | Viewer on all assets   |
+
+<Warning>
+Read access cascades automatically, but execution permissions (run/trigger) may require explicit asset-level grants due to known gaps in the system. If a project Viewer needs to run specific agents, grant them Member access at the asset level explicitly.
+</Warning>
+
+Project Members do **not** automatically have access to all assets. Members must be granted asset-level permissions explicitly for each asset they need to access.
+
+----
+
+## Technical implementation notes
+
+The following is relevant primarily for API users and developers integrating directly with the authorization system.
+
+- **Member vs operator:** The "Member" role label in the UI maps to the `operator` role in the underlying authorization system. When querying permissions via the API, use `operator` rather than `member`.
+- **Authorization system:** The platform uses OpenFGA for authorization. Some parts of the system use a legacy authorization layer that may produce slightly different behavior in edge cases.
+- **Embeddable agents:** Agents shared via public embed links (Chat UI, Chat Widget) may behave differently under the legacy authorization system. Test permissions explicitly when deploying embedded agents.
 
 ----
 


### PR DESCRIPTION
This PR consolidates 2 drafter PRs that all modify the RBAC docs. Each section below is the original description from a source PR. Opening as draft for review before closing the source PRs.

## Source PRs (kept open until confirmed)
- #583 — [TSP-1150](https://linear.app/relevance/issue/TSP-1150): fix critical RBAC permission inaccuracies
- #586 — [TSP-1152](https://linear.app/relevance/issue/TSP-1152): RBAC transition guide and legacy permissions note

## Files touched
- `admin/project-management/add-members.mdx` — adds Chat role accordion, simplifies the Viewer description, and reframes the existing Info banner so it links to both the RBAC docs and the transition guide
- `enterprise/rbac.mdx` — adds clarifying callouts (Editor scoping, Viewer access, asset visibility), plus three new H2 sections: "Transitioning to RBAC", "Permission inheritance and cascading", and "Technical implementation notes"

## Reconciliation note
Both PRs edit the same two files. #586 frames the legacy page as describing only Admin/Editor/Viewer; #583 adds Chat to that same page. Reconciled the framing in one pass so the docs don't ship two contradicting messages.

---

# #583 — docs(TSP-1150): fix critical RBAC permission inaccuracies

## Summary

- **Fixes incorrect Viewer permissions** in `add-members.mdx`: removes the false "Can run agents" claim from the Viewer role
- **Adds missing Chat role** to `add-members.mdx` (was entirely absent from the page)
- **Updates Viewer description** to align with `enterprise/rbac.mdx`: view-only, cannot run or edit
- **Adds link** from `add-members.mdx` to the full RBAC reference page

In `enterprise/rbac.mdx`:
- **Editor clarification**: Editor is project-level only; Project Editors auto-get Admin on all project assets
- **Viewer clarifications** (both project-level and asset-level): no field-level redaction — Viewers see full configs or nothing, not partial metadata
- **New section: "Permission inheritance and cascading"**: documents how project roles cascade to assets, and that Members require explicit asset-level grants
- **New section: "Technical implementation notes"**: covers Member/operator naming, OpenFGA usage, and legacy system behavior for embedded agents

## Context

Customer confusion traced to two root causes:
1. The `add-members.mdx` Viewer role incorrectly stated Viewers can run agents (they cannot — `can_trigger` requires operator/Member minimum)
2. Permission cascading behavior was completely undocumented, causing confusion when project-level Viewer access didn't cascade as expected to "invited users only" agents

Fixes: https://linear.app/relevance/issue/TSP-1150/

## Test plan

- [ ] Verify `add-members.mdx` Viewer accordion no longer mentions running agents
- [ ] Verify Chat role accordion is present in `add-members.mdx`
- [ ] Verify Info callout links correctly to `/enterprise/rbac`
- [ ] Verify new sections render correctly in Mintlify preview
- [ ] Verify Warning callout in permission inheritance section is a single paragraph (CLAUDE.md compliant)
- [ ] Verify all headings are in sentence case

---

# #586 — docs(TSP-1152): add RBAC transition guide and legacy permissions note

## Summary

- Added a new **Transitioning to RBAC** section to `enterprise/rbac.mdx` covering:
  - What the legacy permission system looked like (3 roles, no asset-level granularity)
  - How legacy roles map to RBAC roles by default during migration
  - Critical warning about the Viewer role behavior change (legacy Viewers could run agents; RBAC Viewers cannot)
  - What changes after RBAC is enabled (asset-level enforcement, 403 errors without explicit grants, per-tool credential scoping)
  - Admin action items checklist for post-migration access review
- Added a legacy permissions callout to `admin/project-management/add-members.mdx` directing RBAC-enabled orgs to the RBAC docs

## Test plan

- [ ] Verify the Transitioning to RBAC section renders correctly in Mintlify preview
- [ ] Verify the Info callout on add-members.mdx renders and the link to `/enterprise/rbac` resolves
- [ ] Check all internal links (`/get-started/chat/introduction`, `/enterprise/rbac`) are valid
- [ ] Confirm sentence case on all headings

Linear: https://linear.app/relevance/issue/TSP-1152/

---

## Linear
- [TSP-1150](https://linear.app/relevance/issue/TSP-1150)
- [TSP-1152](https://linear.app/relevance/issue/TSP-1152)
