### PR TITLE
docs(inventor): consolidated Inventor docs (overview + credit counter)

### DIFF
--- a/admin/subscriptions/plans.mdx
+++ b/admin/subscriptions/plans.mdx
@@ -95,6 +95,10 @@ description: "Understand different plans at Relevance AI, and learn how to manag
     2. Click the number next to 'Credits used'
     3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
 
+    <Note>
+      If you're building an agent with Inventor, the Inventor sidebar shows a real-time credit counter for credits used during that session. See [Inventor](/build/agents/inventor#credit-usage-in-the-inventor-sidebar) for details.
+    </Note>
+
     ### How many Vendor Credits and Actions do I have left?
 
     <img
@@ -321,6 +325,10 @@ description: "Understand different plans at Relevance AI, and learn how to manag
     1. First, access the run of your Agent you want to view credits on, on the Run screen
     2. Click the number next to 'Credits used'
     3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
+
+    <Note>
+      If you're building an agent with Inventor, the Inventor sidebar shows a real-time credit counter for credits used during that session. See [Inventor](/build/agents/inventor#credit-usage-in-the-inventor-sidebar) for details.
+    </Note>
 
     ## Monitoring concurrency usage
 

--- a/build/agents/inventor.mdx
+++ b/build/agents/inventor.mdx
@@ -1,0 +1,75 @@
+---
+title: "Inventor"
+sidebarTitle: "Inventor"
+description: "Inventor is Relevance AI's AI-powered agent and tool builder. Describe what you want to build and Inventor generates a working agent or tool for you."
+---
+
+Inventor generates agents and tools from natural language descriptions. You encounter it when creating a new agent (the **Invent** option) or a new tool — it opens a sidebar where you describe what you want, and Inventor sets up the configuration for you.
+
+## How Inventor works
+
+When you select **Invent** during agent or tool creation, a sidebar opens on the right side of the screen. Type a description of what you want to build and Inventor generates the agent or tool based on your input.
+
+For agents, Inventor configures the prompt and suggests relevant tools. For tools, it builds out the steps and logic of the tool. You can then review and adjust anything before saving.
+
+**Tips for effective descriptions:**
+
+- Be specific about the task, expected output, and any integrations the agent should use
+- Include the type of input it will receive (e.g. a company name, a URL, a list of contacts)
+- Mention how it should handle edge cases if you have specific requirements
+
+**Example:** *"Create an agent that researches a company before a sales call. It should use web search to find recent news, funding, and key contacts, then output a one-page brief with company overview, decision makers, and talking points."*
+
+After Inventor generates the initial configuration, you can continue the conversation in the sidebar to refine it — ask it to add a tool, adjust the prompt, or change how the agent behaves.
+
+## Credit usage in the Inventor sidebar
+
+While using Inventor, the sidebar displays a real-time credit counter showing how many credits you've used during the session. The counter shows "X credits used" with a coins icon, and updates each time you interact with the AI — for example, when generating an agent, requesting adjustments, or asking follow-up questions.
+
+Each AI interaction in Inventor consumes credits. This counter is specific to your current Inventor session and is separate from the organization-wide credit counter in the bottom-left of the platform, which shows your remaining balance for the billing period.
+
+For details on managing your credit balance and monitoring usage, see [Plans and credits](/admin/subscriptions/plans).
+
+## Feedback and bug reporting
+
+Inventor includes built-in feedback tools to help improve its performance over time.
+
+### Thumbs up and thumbs down
+
+Each AI message in the Inventor sidebar has thumbs up and thumbs down buttons. Use these to rate Inventor's responses:
+
+- **Thumbs up** — the response was accurate and helpful
+- **Thumbs down** — the response was incorrect, unhelpful, or the generated agent/tool didn't match what you described
+
+These ratings are used to improve Inventor's output quality.
+
+### Reporting issues with thumbs down
+
+When you click thumbs down, a popup appears where you can describe the problem in detail and submit a bug report directly to the Relevance AI team. You don't need to leave the interface or send a separate email.
+
+Useful details to include in a bug report:
+
+- What you asked Inventor to build
+- What it generated
+- What was wrong or missing
+- What you expected instead
+
+### Automatic failure detection
+
+Inventor monitors conversations for repeated failures. If it detects that a conversation is consistently not producing useful results, it automatically files a bug report — up to two times per conversation. This helps the team identify issues even when users don't submit manual reports.
+
+## When to use Inventor
+
+Inventor works best when:
+
+- You know what you want and can describe it in plain language
+- You want a working starting point quickly and plan to refine it afterward
+- You're building a tool or agent for the first time and want guidance on structure
+
+For more complex agents with specific workflow requirements, you can start with Inventor and then adjust the configuration manually in the agent builder.
+
+## Related pages
+
+- [Create an agent](/build/agents/create-an-agent) — the creation flow where you choose Inventor or other options
+- [Plans and credits](/admin/subscriptions/plans) — manage your credit balance and monitor usage
+- [Support](/get-started/support) — contact the team directly for issues not covered by in-app bug reporting

--- a/docs.json
+++ b/docs.json
@@ -89,6 +89,7 @@
             "group": "Agents",
             "pages": [
               "build/agents/create-an-agent",
+              "build/agents/inventor",
               {
                 "group": "Build an Agent",
                 "pages": [


### PR DESCRIPTION
This PR consolidates 2 drafter PRs covering Inventor. Each section below is the original description from a source PR. Opening as draft for review before closing the source PRs.

## Source PRs (kept open until confirmed)
- #594 — [TSP-1172](https://linear.app/relevance/issue/TSP-1172): new Inventor documentation page
- #597 — [TSP-1171](https://linear.app/relevance/issue/TSP-1171): real-time credit counter in the Inventor interface

## Files touched
- `build/agents/inventor.mdx` — new page with overview, credit counter section, feedback/bug reporting, and usage guidance
- `admin/subscriptions/plans.mdx` — adds Note callouts pointing to the Inventor credit counter section
- `docs.json` — adds Inventor to the Agents nav group

## Reconciliation note
#597 originally added credit counter content to `create-an-agent.mdx` because the dedicated Inventor page didn't exist yet. With #594 introducing that page, the credit counter belongs there rather than on the creation flow page. One coherent Inventor doc, one cross-reference from Plans.

---

# #594 — docs(TSP-1172): add Inventor documentation

## Summary

- Adds `/build/agents/inventor.mdx` — a new documentation page for the Inventor AI-powered agent and tool builder
- Documents the sidebar interface, how to write effective descriptions, and feedback features (thumbs up/down, bug reporting popup, automatic failure detection)
- Updates `docs.json` to add the page to navigation under Agents, positioned after "Create an Agent"

## Linear issue

https://linear.app/relevance/issue/TSP-1172/

## Test plan

- [ ] Page renders correctly in Mintlify preview
- [ ] Navigation entry appears in the Agents section after "Create an Agent"
- [ ] All internal links resolve (`/build/agents/create-an-agent`, `/get-started/support`)
- [ ] Headings are in sentence case
- [ ] No banned words used

---

# #597 — docs(TSP-1171): document real-time credit counter in Inventor interface

## Summary

- Adds a `### Credit usage in the Inventor sidebar` subsection to the **Option 1: Invent an Agent** section in `build/agents/create-an-agent.mdx`, describing the real-time "X credits used" counter with coins icon, how it updates during AI interactions, and how it differs from the org-wide counter
- Adds a `<Note>` callout to both billing tabs in `admin/subscriptions/plans.mdx` (under the individual Agent-level monitoring section) pointing readers to the Inventor interface details

## Test plan

- [ ] Verify the new subsection renders correctly under Option 1 on the Create an Agent page
- [ ] Verify the `<Note>` callouts appear in both the New billing and Old billing tabs on the Plans and credits page
- [ ] Verify all cross-reference links resolve correctly

Linear issue: https://linear.app/relevance/issue/TSP-1171/

---

## Linear
- [TSP-1171](https://linear.app/relevance/issue/TSP-1171)
- [TSP-1172](https://linear.app/relevance/issue/TSP-1172)
