### PR TITLE
docs(mcp): consolidated MCP server, skills, slide builder, and evals docs

### DIFF
--- a/build/agents/build-your-agent/evals.mdx
+++ b/build/agents/build-your-agent/evals.mdx
@@ -12,6 +12,12 @@ The Evals section is your command center for testing and evaluating AI Agent per
 
 ![Evals section showing Test Suites, Evaluators, Runs, and Performance](/images/agent/agent-evals.png)
 
+## Programmatic access
+
+You can manage the full evaluation lifecycle programmatically using the Relevance AI MCP server. This covers creating test sets and test cases, configuring evaluator rules and tool simulations, triggering runs, and retrieving results — enabling CI/CD integration and automated testing workflows. See [Programmatic evals via MCP](/build/agents/build-your-agent/evals/programmatic-evals) for details.
+
+---
+
 ## What you can do with Evals
 
 <CardGroup cols={3}>

--- a/build/agents/build-your-agent/evals/programmatic-evals.mdx
+++ b/build/agents/build-your-agent/evals/programmatic-evals.mdx
@@ -1,0 +1,234 @@
+---
+title: "Programmatic evals via MCP"
+sidebarTitle: "Programmatic evals"
+description: "Manage the full evaluation lifecycle programmatically using MCP tools from your AI coding assistant."
+---
+
+The Relevance AI MCP server includes 19 tools for managing evaluations programmatically. This covers the complete evaluation lifecycle: creating test sets and test cases, configuring evaluator rules and tool simulations, running evaluations, and monitoring batch results.
+
+This enables CI/CD integration, automated testing frameworks, and bulk operations that would be impractical to do through the UI.
+
+<Info>
+This page covers the MCP tools for programmatic eval management. For the UI-based workflow, see [Evals](/build/agents/build-your-agent/evals).
+</Info>
+
+<Info>
+**Rollout Status**: Evals is currently being rolled out progressively, starting with Enterprise customers. If you're an Enterprise customer and don't see this feature in your account yet, reach out to your account manager to discuss access.
+</Info>
+
+---
+
+## Prerequisites
+
+You need the Relevance AI MCP server connected to your AI coding assistant before using these tools. See the [MCP Server](/integrations/mcp/programmatic-gtm/mcp-server) page for setup instructions.
+
+For better results, also clone the [agent skills](/integrations/mcp/programmatic-gtm/agent-skills) repository — it gives your assistant the knowledge to use MCP tools correctly.
+
+---
+
+## Managing test sets
+
+Test sets (also called Test Suites in the UI) are containers for test cases that you run together as a group.
+
+### What you can do
+
+- Create a new test set for an agent
+- List all test sets for an agent
+- Get the details of a specific test set
+- Update a test set's name or configuration
+- Delete a test set
+
+### Example prompts
+
+```
+Create a test set called "Customer Support Regression" for agent [agent-id]
+```
+
+```
+List all test sets for my support agent
+```
+
+```
+Delete the test set named "Draft Tests" from agent [agent-id]
+```
+
+---
+
+## Managing test cases
+
+Test cases are individual scenarios within a test set. Each test case defines a simulated user persona, an opening message, conversation limits, and its own evaluator rules.
+
+### What you can do
+
+- Create a test case within a test set
+- List all test cases in a test set
+- Get the details of a specific test case
+- Update a test case's scenario, persona, or configuration
+- Delete a test case
+
+### Example prompts
+
+```
+Add a test case to the "Customer Support Regression" test set:
+- Scenario name: Billing Dispute
+- Persona: An upset customer who was charged twice for the same order
+- First message: "I've been double charged and no one is helping me"
+- Max turns: 8
+```
+
+```
+List all test cases in test set [test-set-id]
+```
+
+```
+Update the "Billing Dispute" test case to increase max turns to 12
+```
+
+---
+
+## Configuring evaluator rules
+
+Evaluator rules define the criteria used to assess whether an agent's response passes or fails a test case. You can add, update, and remove evaluator rules on individual test cases.
+
+### Evaluator rule types
+
+| Type | What it checks |
+|------|---------------|
+| LLM Judge | Evaluates the conversation against a prompt you write, using an LLM to score the result |
+| String Contains | Checks whether the agent's response includes specific text |
+| String Equals | Checks whether the agent's response exactly matches an expected value |
+| Tool Usage | Checks whether a specific tool was used, and how many times or in what position |
+
+### What you can do
+
+- Add an evaluator rule to a test case
+- Update an existing evaluator rule
+- Remove an evaluator rule from a test case
+- List all evaluator rules on a test case
+
+### Example prompts
+
+```
+Add an LLM Judge evaluator to test case [test-case-id]:
+- Name: Empathy Check
+- Prompt: Did the agent acknowledge the customer's frustration before offering a solution?
+```
+
+```
+Add a Tool Usage evaluator to test case [test-case-id]:
+- Name: Escalation Tool Used
+- Tool: escalate_to_human
+- Check that it was used at least once
+```
+
+```
+Remove the "String Contains" evaluator from test case [test-case-id]
+```
+
+---
+
+## Configuring tool simulation
+
+Tool simulation lets you emulate tool responses during evaluations without actually calling the real tools. This is useful for testing how your agent handles specific tool outputs without incurring real API calls or side effects.
+
+Tool simulations are configured at the test case level. You specify the tool to simulate and a prompt describing the fake response the tool should return.
+
+### Example prompts
+
+```
+Add a tool simulation to test case [test-case-id]:
+- Tool: get_customer_account
+- Simulation prompt: Return a customer account showing two identical charges of $49.99 on the same date
+```
+
+```
+Update the tool simulation for "get_order_status" in test case [test-case-id] to return a delayed shipment scenario
+```
+
+```
+Remove the tool simulation for "send_email" from test case [test-case-id]
+```
+
+---
+
+## Running evaluations
+
+You can trigger evaluation runs programmatically against a test set. This is the same operation as clicking **Run** in the UI, but callable from scripts, CI pipelines, and automated workflows.
+
+### What you can do
+
+- Run a test set (runs all test cases in the set)
+- Run an individual test case
+- Include or exclude global evaluators from a run
+
+### Example prompts
+
+```
+Run the "Customer Support Regression" test set for agent [agent-id]
+```
+
+```
+Run test case [test-case-id] and include the "Professional Tone" global evaluator
+```
+
+```
+Trigger an evaluation run on test set [test-set-id] and name it "v2.3 release check"
+```
+
+---
+
+## Monitoring batch results
+
+After triggering a run, you can retrieve the results programmatically — including per-test-case scores, evaluator verdicts, and conversation logs.
+
+### What you can do
+
+- List all evaluation runs for a test set
+- Get the detailed results for a specific run, including scores and evaluator verdicts
+- Check whether a run is still in progress or complete
+
+### Example prompts
+
+```
+List all evaluation runs for test set [test-set-id]
+```
+
+```
+Get the results for evaluation run [run-id] — show me which test cases passed and which failed
+```
+
+```
+Check if the latest evaluation run for the "Customer Support Regression" test set has completed
+```
+
+---
+
+## CI/CD integration
+
+Because evaluation runs are fully programmable via MCP, you can integrate them into automated pipelines:
+
+- Trigger a test set run as part of a pre-deployment check
+- Poll for completion and parse pass/fail status
+- Block deployment if scores fall below a threshold
+
+<Accordion title="Example CI/CD workflow using an AI coding assistant">
+Ask your AI coding assistant:
+
+```
+1. Trigger an evaluation run for test set [test-set-id] on agent [agent-id]
+2. Poll every 10 seconds until the run is complete
+3. Check whether all test cases passed
+4. If any test case scored below 80%, list the failing cases with their evaluator verdicts
+5. Return a summary with overall pass rate
+```
+
+Your assistant will use the MCP eval tools to carry out each step and return a structured report you can act on.
+</Accordion>
+
+---
+
+## Learn more
+
+- [Evals (UI workflow)](/build/agents/build-your-agent/evals) — create and manage evaluations through the Relevance AI interface
+- [MCP Server](/integrations/mcp/programmatic-gtm/mcp-server) — connect your AI coding assistant to Relevance AI
+- [Agent Skills](/integrations/mcp/programmatic-gtm/agent-skills) — give your assistant built-in knowledge of Relevance AI tools

--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,13 @@
                   "build/agents/build-your-agent/alerts",
                   "build/agents/build-your-agent/memory",
                   "build/agents/build-your-agent/variables",
-                  "build/agents/build-your-agent/evals",
+                  {
+                    "group": "Evals",
+                    "pages": [
+                      "build/agents/build-your-agent/evals",
+                      "build/agents/build-your-agent/evals/programmatic-evals"
+                    ]
+                  },
                   {
                     "group": "Trigger Types",
                     "pages": [
@@ -384,7 +390,8 @@
                   "integrations/mcp/programmatic-gtm/claude-code",
                   "integrations/mcp/programmatic-gtm/codex",
                   "integrations/mcp/programmatic-gtm/mcp-server",
-                  "integrations/mcp/programmatic-gtm/agent-skills"
+                  "integrations/mcp/programmatic-gtm/agent-skills",
+                  "integrations/mcp/programmatic-gtm/slide-builder"
                 ]
               },
               "integrations/mcp/mcp-client"

--- a/get-started/chat/chat-agents/slide-builder.mdx
+++ b/get-started/chat/chat-agents/slide-builder.mdx
@@ -192,6 +192,16 @@ We also have a number of YouTube tutorials you can use to follow along with and 
 
 ---
 
+## Programmatic access via MCP
+
+AI assistants connected to Relevance AI via MCP (Claude, Cursor, VS Code, ChatGPT, and others) can access Slide Builder directly — creating presentations, managing BrandKits and Templates, exporting slides, and working with version history through natural language prompts.
+
+<Card title="Slide Builder via MCP" icon="plug" href="/integrations/mcp/programmatic-gtm/slide-builder">
+  Learn how to create and manage presentations programmatically using the Relevance AI MCP server.
+</Card>
+
+---
+
 ## What's next?
 
 <CardGroup cols={2}>

--- a/get-started/core-concepts/programmatic-gtm.mdx
+++ b/get-started/core-concepts/programmatic-gtm.mdx
@@ -23,6 +23,9 @@ Connect your AI coding environment to Relevance AI to start building programmati
   <Card title="Agent Skills" icon="graduation-cap" href="/integrations/mcp/programmatic-gtm/agent-skills">
     Clone the agent skills repository to give your AI coding assistant built-in knowledge of Relevance AI.
   </Card>
+  <Card title="Slide Builder" icon="presentation-screen" href="/integrations/mcp/programmatic-gtm/slide-builder">
+    Create presentations, manage BrandKits and Templates, and export slides via MCP.
+  </Card>
 </CardGroup>
 
 ---
@@ -58,6 +61,9 @@ Once connected, your AI client gets full access to your Relevance AI project. Th
   </Card>
   <Card title="Update configurations" icon="gear">
     Modify agent instructions, tool settings, and workflow logic.
+  </Card>
+  <Card title="Create presentations" icon="presentation-screen">
+    Build AI-generated slide decks, manage BrandKits and Templates, and export in multiple formats — all from your AI client.
   </Card>
 </CardGroup>
 
@@ -127,6 +133,31 @@ Once connected, your AI client gets full access to your Relevance AI project. Th
         *"Create a tool that generates a personalised cold email based on a prospect's LinkedIn profile and our product's value props."*
       </Accordion>
     </AccordionGroup>
+  </Tab>
+
+  <Tab title="Slide Builder">
+    Create presentations, manage BrandKits and Templates, and export slides — all from your AI client without opening the Chat interface.
+
+    **Example prompts:**
+
+    <AccordionGroup>
+      <Accordion title="Create a pitch deck">
+        *"Create a 10-slide investor pitch deck for our Series A round. Include slides on the problem, solution, market size, business model, traction, team, and ask."*
+      </Accordion>
+      <Accordion title="Build branded presentations">
+        *"Create a BrandKit called 'Acme Corp' using our primary colour #2563EB and Inter as the body font. Then use it to build a 6-slide product overview deck."*
+      </Accordion>
+      <Accordion title="Reuse a template">
+        *"Use the 'Quarterly Business Review' template to create a presentation for Q1 2026. Pull the metrics from this spreadsheet."*
+      </Accordion>
+      <Accordion title="Export slides">
+        *"Export the current presentation as a PPTX file and also as individual PNG images."*
+      </Accordion>
+    </AccordionGroup>
+
+    <Card title="Slide Builder via MCP" icon="presentation-screen" href="/integrations/mcp/programmatic-gtm/slide-builder">
+      See the full list of capabilities and example prompts for Slide Builder via MCP.
+    </Card>
   </Tab>
 
   <Tab title="Troubleshoot">

--- a/integrations/mcp/programmatic-gtm/agent-skills.mdx
+++ b/integrations/mcp/programmatic-gtm/agent-skills.mdx
@@ -54,14 +54,96 @@ The agent skills repository contains structured reference documentation that you
 
 <CardGroup cols={2}>
   <Card title="SKILL.md" icon="book">
-    The main skill definition — covers all 46 MCP tools, critical usage rules, and workflow patterns your assistant should follow.
+    The main skill definition — covers all 65 MCP tools, critical usage rules, and workflow patterns your assistant should follow.
   </Card>
   <Card title="Reference docs" icon="folder-open">
     Detailed guides for agents, tools, workforces, knowledge, analytics, and evals that the assistant reads when working on specific tasks.
   </Card>
 </CardGroup>
 
-### Topics covered
+---
+
+## Creating skills programmatically
+
+While you can manually create and edit `SKILL.md` files in the agent skills repository, you can also create and manage skills programmatically using the Skills API. This is useful for automation workflows, CI/CD pipelines, or any scenario where you need to generate or update skills without manual editing.
+
+### Structured fields
+
+The Skills API accepts four structured fields when creating or updating a skill:
+
+<AccordionGroup>
+  <Accordion title="name (required)">
+    A unique identifier for the skill. Must be lowercase with hyphens, maximum 64 characters.
+
+    Example: `pdf-processing`
+  </Accordion>
+
+  <Accordion title="description (required)">
+    A comprehensive description of what the skill does. This is used to help AI agents understand the skill's purpose and capabilities. Maximum 1024 characters.
+
+    Example: `Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs`
+  </Accordion>
+
+  <Accordion title="when_to_use (optional)">
+    Activation hints that help AI agents determine when to use this skill. These hints appear in the skills catalog for trusted skills and provide specific guidance on the contexts or scenarios where the skill should be activated.
+
+    Unlike `description` (which explains what the skill does), `when_to_use` tells the agent when to reach for it. This distinction matters because an agent might recognize a skill is relevant to PDFs but not know whether to activate it for a general document question versus a specific PDF task.
+
+    Example: `Use when the user mentions PDFs, asks to extract data from documents, needs to fill forms, or wants to combine multiple files`
+  </Accordion>
+
+  <Accordion title="content">
+    The full Markdown content of the skill instructions. This is equivalent to the body of `SKILL.md` — include tool descriptions, usage patterns, critical rules, and any context the AI assistant needs to use the skill correctly.
+  </Accordion>
+</AccordionGroup>
+
+### Trusted skills
+
+Trusted skills are verified skills that appear in the skills catalog with enhanced visibility. When a skill is marked as trusted, the `when_to_use` field is displayed prominently to help AI agents decide whether to activate it for a given task. If you are building skills intended for catalog distribution, populate `when_to_use` with specific, scenario-based hints rather than generic descriptions.
+
+### Code example
+
+<Accordion title="Create a skill with all structured fields">
+```python
+import requests
+
+API_URL = "https://api.relevanceai.com/v1/skills"
+headers = {
+    "Authorization": "Bearer YOUR_API_KEY",
+    "Content-Type": "application/json",
+}
+
+skill = {
+    "name": "pdf-processing",
+    "description": "Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs",
+    "when_to_use": "Use when the user mentions PDFs, asks to extract data from documents, needs to fill forms, or wants to combine multiple files",
+    "content": """# PDF processing
+
+## Overview
+Use these tools to work with PDF files in Relevance AI.
+
+## Tools
+- `pdf_extract_text` — extracts plain text from a PDF file
+- `pdf_extract_tables` — returns structured table data from a PDF
+- `pdf_fill_form` — fills a PDF form given a field map
+- `pdf_merge` — combines multiple PDFs into one
+
+## Usage rules
+- Always check the file size before extracting — files over 50 MB may time out
+- Use `pdf_extract_tables` instead of `pdf_extract_text` when the user needs structured data
+- `pdf_fill_form` requires the exact field names from the PDF; fetch them with `pdf_get_form_fields` first
+""",
+}
+
+response = requests.post(API_URL, json=skill, headers=headers)
+response.raise_for_status()
+print(response.json())
+```
+</Accordion>
+
+---
+
+## Topics covered
 
 <CardGroup cols={3}>
   <Card title="Agents" icon="robot">
@@ -80,7 +162,10 @@ The agent skills repository contains structured reference documentation that you
     Usage metrics and reporting capabilities.
   </Card>
   <Card title="Evals" icon="check-double">
-    Testing agent behaviour with evaluation cases.
+    Full evaluation lifecycle — creating test sets and test cases, configuring evaluator rules and tool simulations, running evaluations, and monitoring batch results.
+  </Card>
+  <Card title="Slide Builder" icon="presentation-screen">
+    Creating presentations, managing BrandKits and Templates, exporting slides, and version history.
   </Card>
 </CardGroup>
 

--- a/integrations/mcp/programmatic-gtm/codex.mdx
+++ b/integrations/mcp/programmatic-gtm/codex.mdx
@@ -93,6 +93,20 @@ Once connected, you can start building immediately:
     > My BDR agent is letting unqualified leads through — review its instructions and fix it
     ```
   </Tab>
+
+  <Tab title="Slide Builder">
+    ```
+    > Create a 10-slide pitch deck for our Series A round — problem, solution, market size, traction, team, and ask
+    ```
+
+    ```
+    > Create a BrandKit called "Acme Corp" using our primary colour #2563EB, then build a 6-slide product overview deck with it
+    ```
+
+    ```
+    > Use the "Quarterly Business Review" template to create a Q1 2026 presentation, then export it as a PPTX
+    ```
+  </Tab>
 </Tabs>
 
 ---

--- a/integrations/mcp/programmatic-gtm/mcp-server.mdx
+++ b/integrations/mcp/programmatic-gtm/mcp-server.mdx
@@ -236,6 +236,16 @@ Each entry authenticates independently against its own project, so you can acces
 
 ---
 
+## Slide Builder
+
+Once connected, your AI assistant can create and manage presentations directly — without opening the Chat interface. This includes creating slide decks from prompts, managing BrandKits and Templates, exporting slides as PDF, PPTX, Images, or JSON, and working with version history.
+
+<Card title="Slide Builder via MCP" icon="presentation-screen" href="/integrations/mcp/programmatic-gtm/slide-builder">
+  See all Slide Builder capabilities and example prompts.
+</Card>
+
+---
+
 ## Add agent skills
 
 The MCP server gives your AI assistant the ability to call Relevance AI tools, but it doesn't know _how_ to use them well. For better results, pair it with the [agent skills](/integrations/mcp/programmatic-gtm/agent-skills) repository — a local reference that teaches your assistant how to work with agents, tools, workforces, knowledge, and more.
@@ -246,27 +256,31 @@ The MCP server gives your AI assistant the ability to call Relevance AI tools, b
 
 When triggering agents via MCP, you have two execution modes available depending on how long your agent takes to complete.
 
+<Warning>
+  **Breaking change:** `relevance_trigger_agent` is now asynchronous — it returns a `conversation_id` immediately without waiting for the agent to finish. If you need synchronous (blocking) behavior, use `relevance_trigger_agent_sync` instead. Existing integrations that relied on `relevance_trigger_agent` being synchronous must be updated.
+</Warning>
+
 ### Execution modes
 
 <Tabs>
   <Tab title="Synchronous">
-    The `relevance_trigger_agent` tool waits for the agent to finish and returns the result directly. It has a 120-second timeout, so use it for agents that complete quickly — single-step agents with minimal tool usage and no workforce nodes.
+    The `relevance_trigger_agent_sync` tool waits for the agent to finish and returns the result directly. It has a 120-second timeout, so use it for agents that complete quickly — single-step agents with minimal tool usage and no workforce nodes.
   </Tab>
 
   <Tab title="Asynchronous">
-    The `relevance_trigger_agent_async` and `relevance_poll_agent_result` tools work together with no timeout limit. The trigger returns immediately with a conversation ID, which you then poll to check status and retrieve results. Use this for agents with workforce nodes, multi-step chains, external API calls, or any execution expected to exceed 2 minutes.
+    The `relevance_trigger_agent` and `relevance_poll_agent_result` tools work together with no timeout limit. The trigger returns immediately with a conversation ID, which you then poll to check status and retrieve results. Use this for agents with workforce nodes, multi-step chains, external API calls, or any execution expected to exceed 2 minutes.
   </Tab>
 </Tabs>
 
 <Warning>
-  If you encounter timeout errors with `relevance_trigger_agent`, switch to the async pattern. Agents with workforce nodes should always use async execution.
+  If you encounter timeout errors with `relevance_trigger_agent_sync`, switch to the async pattern. Agents with workforce nodes should always use async execution.
 </Warning>
 
 ### Async execution workflow
 
 <Steps>
   <Step title="Trigger the agent">
-    Call `relevance_trigger_agent_async` with your agent parameters. This returns immediately with a `conversation_id`.
+    Call `relevance_trigger_agent` with your agent parameters. This returns immediately with a `conversation_id`.
   </Step>
 
   <Step title="Poll for results">
@@ -303,7 +317,7 @@ When triggering agents via MCP, you have two execution modes available depending
   </Accordion>
 
   <Accordion title="Agent execution timeouts">
-    Timeout errors from `relevance_trigger_agent` mean your agent exceeded the 120-second synchronous limit. Switch to `relevance_trigger_agent_async` and `relevance_poll_agent_result` instead. See [handling long-running agent executions](#handling-long-running-agent-executions) for the full workflow. Agents with workforce nodes, multi-step chains, or complex workflows should always use the async pattern.
+    Timeout errors from `relevance_trigger_agent_sync` mean your agent exceeded the 120-second synchronous limit. Switch to `relevance_trigger_agent` and `relevance_poll_agent_result` instead. See [handling long-running agent executions](#handling-long-running-agent-executions) for the full workflow. Agents with workforce nodes, multi-step chains, or complex workflows should always use the async pattern.
   </Accordion>
 </AccordionGroup>
 

--- a/integrations/mcp/programmatic-gtm/slide-builder.mdx
+++ b/integrations/mcp/programmatic-gtm/slide-builder.mdx
@@ -1,0 +1,285 @@
+---
+title: "Slide Builder"
+sidebarTitle: "Slide Builder"
+description: "Create and manage AI-generated presentations via MCP using Claude, Cursor, or any MCP-compatible AI client."
+---
+
+AI assistants connected to Relevance AI via MCP can access the full Slide Builder — creating presentations, managing BrandKits and Templates, exporting slides, and working with version history — all through natural language prompts.
+
+---
+
+## Quick start
+
+<Steps>
+  <Step title="Connect the MCP server">
+    Set up the Relevance AI MCP server for your AI client. Follow the instructions on the [MCP Server](/integrations/mcp/programmatic-gtm/mcp-server) page for your specific client (Claude Desktop, Cursor, VS Code, ChatGPT, and others).
+  </Step>
+
+  <Step title="Authenticate">
+    When you first connect, you will be prompted to authenticate with your Relevance AI account. Authentication is per project — you will have access to the Slide Builder in whichever project you log in to.
+  </Step>
+
+  <Step title="Start building">
+    You're ready to go. Try one of the example prompts below or describe the presentation you want to create.
+  </Step>
+</Steps>
+
+---
+
+## Available capabilities
+
+Once connected via MCP, your AI assistant can perform all Slide Builder operations:
+
+<CardGroup cols={2}>
+  <Card title="Create presentations" icon="presentation-screen">
+    Generate slide decks from a prompt, topic description, or existing content.
+  </Card>
+  <Card title="Manage BrandKits" icon="palette">
+    Create, update, list, and delete BrandKits to keep presentations on-brand.
+  </Card>
+  <Card title="Create and apply templates" icon="copy">
+    Save presentation structures as reusable templates and apply them to new decks.
+  </Card>
+  <Card title="Export slides" icon="arrow-up-from-bracket">
+    Export presentations as PDF, Images, PPTX, or JSON.
+  </Card>
+  <Card title="Remix designs" icon="shuffle">
+    Refresh slide designs while keeping content intact.
+  </Card>
+  <Card title="Incremental building" icon="layer-group">
+    Build one slide at a time or in batches — review the outline before committing to the full deck.
+  </Card>
+  <Card title="Version history" icon="clock-rotate-left">
+    Access and restore previous versions of a presentation.
+  </Card>
+  <Card title="Dynamic updates" icon="pen-to-square">
+    Modify, rearrange, or update individual slides after the initial build.
+  </Card>
+</CardGroup>
+
+---
+
+## Example prompts
+
+<Tabs>
+  <Tab title="Create presentations">
+    ```
+    > Create a 10-slide pitch deck for a B2B SaaS product that automates expense reporting
+    ```
+
+    ```
+    > Build a presentation about Q3 sales performance using the data in this CSV
+    ```
+
+    ```
+    > Create an onboarding deck for new sales hires — cover our product, ICP, and sales process
+    ```
+  </Tab>
+
+  <Tab title="BrandKits">
+    ```
+    > Create a new BrandKit called "Acme Corp" with blue and white as the primary colours
+    ```
+
+    ```
+    > List all my BrandKits and show me which one is set as default
+    ```
+
+    ```
+    > Update the "Acme Corp" BrandKit to use a more formal tone and add our new logo
+    ```
+  </Tab>
+
+  <Tab title="Templates">
+    ```
+    > Save the pitch deck I just created as a template called "Standard Pitch"
+    ```
+
+    ```
+    > Create a new presentation using the "Weekly Report" template — the topic is last week's marketing metrics
+    ```
+
+    ```
+    > List all my templates and describe what each one is for
+    ```
+  </Tab>
+
+  <Tab title="Export and remix">
+    ```
+    > Export the current presentation as a PPTX file
+    ```
+
+    ```
+    > Remix the current slides — try a darker, more minimal aesthetic
+    ```
+
+    ```
+    > Export each slide as a PNG image
+    ```
+  </Tab>
+
+  <Tab title="Incremental building">
+    ```
+    > Create a 12-slide product demo deck, but only build the first slide so I can review the style
+    ```
+
+    ```
+    > Show me the outline for a presentation about machine learning in healthcare, then wait for my approval before building
+    ```
+
+    ```
+    > Build slides 4 through 7 of the current presentation
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Working with BrandKits via MCP
+
+BrandKits define the visual identity of your presentations — colours, fonts, logos, tone, and design guidelines. Your AI assistant can manage BrandKits directly:
+
+<AccordionGroup>
+  <Accordion title="Creating a BrandKit from brand assets">
+    Describe your brand and provide references, and your assistant will create a BrandKit:
+
+    ```
+    > Create a BrandKit called "Tech Startup" — our primary colour is #2563EB,
+      secondary is #1E40AF, we use Inter for body text and Sora for headings,
+      and our tone is confident and direct
+    ```
+  </Accordion>
+
+  <Accordion title="Applying a BrandKit to a new presentation">
+    Specify which BrandKit to use when creating slides:
+
+    ```
+    > Create a 6-slide investor update using the "Acme Corp" BrandKit
+    ```
+  </Accordion>
+
+  <Accordion title="Listing and inspecting BrandKits">
+    Ask your assistant to show you what BrandKits are available:
+
+    ```
+    > List all BrandKits in this project and show the colour palette for each one
+    ```
+  </Accordion>
+
+  <Accordion title="Deleting a BrandKit">
+    Remove a BrandKit you no longer need:
+
+    ```
+    > Delete the BrandKit called "Old Brand 2023"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Working with templates via MCP
+
+Templates capture the structure of a successful slide deck so you can reuse it. Your AI assistant can create, list, and apply templates:
+
+<AccordionGroup>
+  <Accordion title="Saving a presentation as a template">
+    After building a deck you're happy with, save it for future reuse:
+
+    ```
+    > Save the current presentation as a template called "Quarterly Business Review"
+    ```
+  </Accordion>
+
+  <Accordion title="Creating a presentation from a template">
+    Apply a template when starting a new deck:
+
+    ```
+    > Use the "Quarterly Business Review" template to create a presentation for Q4 2025
+    ```
+  </Accordion>
+
+  <Accordion title="Combining BrandKits and templates">
+    You can apply both a template (for structure) and a BrandKit (for visual identity) together:
+
+    ```
+    > Create a presentation using the "Standard Pitch" template and the "Acme Corp" BrandKit,
+      covering our new enterprise product launch
+    ```
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Exporting presentations via MCP
+
+Your AI assistant can export completed presentations in four formats:
+
+| Format | Use case |
+|--------|----------|
+| **PDF** | Sharing or printing the complete deck |
+| **Images** | Embedding individual slides in other documents |
+| **PPTX** | Editing in Microsoft PowerPoint or Google Slides |
+| **JSON** | Saving slide data to recreate or reference in a future session |
+
+<Note>Exported slides show the static final state of each slide. Animations and moving elements are not preserved in exported files.</Note>
+
+Example:
+
+```
+> Export the current presentation as a PDF and also as a PPTX file
+```
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Slide Builder tools not appearing">
+    - Verify you have completed authentication with the MCP server
+    - Check that your Relevance AI project has Slide Builder access
+    - Try disconnecting and reconnecting the MCP server
+  </Accordion>
+
+  <Accordion title="Authentication issues">
+    - Make sure you have an active Relevance AI account
+    - Confirm you have access to the project you are trying to connect to
+    - Try removing and re-adding the MCP server connection in your client
+  </Accordion>
+
+  <Accordion title="Presentation generation errors">
+    - Check that your prompt includes enough context for the assistant to build from
+    - If the deck is large (10+ slides), try using incremental building — ask for the outline first, then build in batches
+    - For complex presentations, break the task into steps: create the outline, review it, then build
+  </Accordion>
+
+  <Accordion title="BrandKit not applying correctly">
+    - Verify the BrandKit name matches exactly — ask your assistant to list all BrandKits first
+    - Make sure the BrandKit was saved successfully before referencing it in a new session
+    - Try explicitly specifying the BrandKit: *"Use the BrandKit named 'Acme Corp'"*
+  </Accordion>
+
+  <Accordion title="Export not working">
+    - Confirm slides have been fully built before attempting an export
+    - Try specifying the format explicitly: *"Export as PDF"*
+    - If export fails, try regenerating the slides first and then exporting
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Slide Builder in Chat" icon="presentation-screen" href="/get-started/chat/chat-agents/slide-builder">
+    Learn about all Slide Builder features available in the Chat interface.
+  </Card>
+  <Card title="MCP Server setup" icon="plug" href="/integrations/mcp/programmatic-gtm/mcp-server">
+    Connect to Relevance AI from Claude Desktop, Cursor, VS Code, ChatGPT, and other MCP clients.
+  </Card>
+  <Card title="Agent Skills" icon="graduation-cap" href="/integrations/mcp/programmatic-gtm/agent-skills">
+    Give your AI assistant built-in knowledge of Relevance AI for better results.
+  </Card>
+  <Card title="Programmatic GTM overview" icon="rocket" href="/integrations/mcp/programmatic-gtm/introduction">
+    Explore everything you can build and manage via MCP.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
This PR consolidates 4 drafter PRs that all touch the Programmatic GTM section. Each section below is the original description from a source PR. Opening as draft for review before closing the source PRs.

## Source PRs (kept open until confirmed)
- #535 — [TSP-1091](https://linear.app/relevance/issue/TSP-1091): `relevance_trigger_agent` breaking change (async by default)
- #548 — [TSP-1092](https://linear.app/relevance/issue/TSP-1092): Slide Builder via MCP (new page + cross-references)
- #557 — [TSP-1107](https://linear.app/relevance/issue/TSP-1107): Skills API structured fields including `when_to_use`
- #598 — [TSP-1164](https://linear.app/relevance/issue/TSP-1164): 19 new MCP evaluation tools (new programmatic-evals page)

## Reconciliation note
Three of the four PRs edit `agent-skills.mdx` and two edit `mcp-server.mdx`. Shipping separately would force conflicts and produce a fragmented Topics covered list. Reconciled the changes in one pass so the section reads coherently.

**Important rerouting:** #548 originally edited `integrations/mcp/programmatic-gtm/introduction.mdx`, but that file was renamed to `get-started/core-concepts/programmatic-gtm.mdx` on main. I redirected those edits (Slide Builder card and tab) to the renamed file.

PR #591 (mcp-client.mdx) stays separate — different file, no overlap.

---

# #535 — docs(TSP-1091): update MCP server docs for relevance_trigger_agent breaking change

## Summary

- `relevance_trigger_agent` is now **asynchronous** (returns `conversation_id` immediately) — breaking change from previous synchronous behavior
- New `relevance_trigger_agent_sync` tool added for synchronous/blocking execution
- `relevance_trigger_agent_async` is replaced by `relevance_trigger_agent`

### Changes made

- Updated synchronous tab to reference `relevance_trigger_agent_sync`
- Updated asynchronous tab to reference `relevance_trigger_agent` (previously `relevance_trigger_agent_async`)
- Updated async workflow step to call `relevance_trigger_agent`
- Updated troubleshooting accordion with correct tool names
- Added prominent Warning callout alerting existing users to the breaking change and directing them to `relevance_trigger_agent_sync` for synchronous behavior

**Linear issue:** https://linear.app/relevance/issue/TSP-1091/

---

# #548 — docs(TSP-1092): document MCP Slide Builder capabilities

## Summary

- Creates a new dedicated page at `integrations/mcp/programmatic-gtm/slide-builder.mdx` documenting all Slide Builder capabilities available via MCP
- Adds cross-links from 5 existing pages (Chat Slide Builder, MCP Server, Programmatic GTM Overview, Agent Skills, OpenAI Codex)
- Updates `docs.json` to include the new page in the Programmatic GTM navigation group

The new page covers: quick start, all available capabilities (BrandKits, Templates, export formats, incremental building, version history), practical example prompts, working with BrandKits and Templates via MCP, exporting in PDF/Images/PPTX/JSON, troubleshooting, and what's next links.

Closes https://linear.app/relevance/issue/TSP-1092/

---

# #557 — docs(TSP-1107): document Skills API structured fields including when_to_use

## Summary

- Adds a new 'Creating skills programmatically' section to agent-skills.mdx
- Documents all four structured fields: name, description, when_to_use, and content
- Explains the distinction between description (what the skill does) and when_to_use (activation hints for AI agents)
- Covers trusted skills and why when_to_use is particularly important for them
- Includes a realistic Python code example demonstrating all four fields
- Promotes Topics covered to a top-level heading since it now sits at the same hierarchy as other sections

Linear issue: https://linear.app/relevance/issue/TSP-1107/

---

# #598 — docs(TSP-1164): Add documentation for 19 new MCP evaluation tools

## Summary

- **New page**: `build/agents/build-your-agent/evals/programmatic-evals.mdx` — documents the 19 new MCP tools covering the full evaluation lifecycle: managing test sets and test cases, configuring evaluator rules and tool simulations, running evaluations, and monitoring batch results
- **Updated**: `build/agents/build-your-agent/evals.mdx` — added a Programmatic Access section near the top linking to the new page
- **Updated**: `integrations/mcp/programmatic-gtm/agent-skills.mdx` — bumped tool count from 46 → 65, expanded the Evals card description to reflect the comprehensive new capabilities
- **Updated**: `docs.json` — converted the flat `evals` nav entry into an Evals group containing both the main page and the new programmatic-evals sub-page

## Context

These docs cover the 19 new MCP tools added in [RelevanceAI/relevance-api-node#13459](https://github.com/RelevanceAI/relevance-api-node/pull/13459). The new tools fill a major gap by enabling programmatic access to evals, supporting CI/CD integration and automated testing frameworks.

Linear issue: https://linear.app/relevance/issue/TSP-1164/

## Test plan

- [ ] New page renders correctly at `/build/agents/build-your-agent/evals/programmatic-evals`
- [ ] Evals group in sidebar shows both the main page and the new sub-page
- [ ] Programmatic Access section appears in evals.mdx and links correctly
- [ ] agent-skills.mdx shows 65 tools and updated Evals card
- [ ] All internal links resolve

---

## Linear
- [TSP-1091](https://linear.app/relevance/issue/TSP-1091)
- [TSP-1092](https://linear.app/relevance/issue/TSP-1092)
- [TSP-1107](https://linear.app/relevance/issue/TSP-1107)
- [TSP-1164](https://linear.app/relevance/issue/TSP-1164)
