### PR TITLE
ci(afdocs): scope check to Mintlify-controllable signal

### DIFF
--- a/.github/workflows/afdocs.yml
+++ b/.github/workflows/afdocs.yml
@@ -11,5 +11,17 @@ jobs:
     # Continue even if the check fails — this is informational only
     continue-on-error: true
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Run afdocs checks
-        run: npx afdocs@latest check https://docs.relevanceai.com --format text --verbose
+        # docs.relevanceai.com 301s cross-host to relevanceai.com/docs.
+        # Targeting the canonical URL avoids the cross-host redirect
+        # warning and lets all checks operate on same-origin content.
+        # Skips and parity exclusions live in agent-docs.config.yml.
+        run: |
+          npx afdocs@0.18.7 check https://relevanceai.com/docs \
+            --format text --verbose

--- a/agent-docs.config.yml
+++ b/agent-docs.config.yml
@@ -1,0 +1,42 @@
+# Configuration for afdocs (https://afdocs.dev).
+# Run via the .github/workflows/afdocs.yml CI check.
+#
+# We skip only checks that depend on Mintlify theme rendering we cannot
+# control from this repo. Everything else stays — those checks catch
+# real PR-level regressions (broken code fences, dropped markdown
+# mirrors, oversized pages, etc.).
+
+skipChecks:
+  # Mintlify renders the full sidebar + nav + TOC into HTML, which turndown
+  # converts into a large block of markdown links before the actual page
+  # content. Pushes real content past the 50% mark on short pages
+  # regardless of how the .mdx is written.
+  - content-start-position
+
+  # Mintlify places the llms.txt directive in the page footer. It is
+  # present on every page but always past the 50% mark, and we cannot
+  # move it without theme changes.
+  - llms-txt-directive-html
+
+options:
+  # Use deterministic sampling so CI runs are reproducible across PRs —
+  # avoids the same workflow flipping between warn/fail purely based on
+  # which random pages got sampled.
+  samplingStrategy: deterministic
+
+  # Strip Mintlify chrome from rendered HTML before comparing against the
+  # .md mirror. Without this, the markdown-content-parity check flags
+  # pages where the only diff is the sidebar/TOC/nav that exists in HTML
+  # and not in the markdown source. Selectors taken from the rendered DOM
+  # on relevanceai.com/docs.
+  parityExclusions:
+    - "#header"
+    - "#footer"
+    - "#sidebar"
+    - "#sidebar-content"
+    - "#navbar"
+    - "#navbar-transition"
+    - "#navigation-items"
+    - "#table-of-contents"
+    - "#table-of-contents-layout"
+    - "#content-side-layout"


### PR DESCRIPTION
## Summary

The Agent-Friendly Docs CI check (`afdocs`) was permanently red on every PR because it crawls live prod and most failures come from Mintlify theme rendering — things no doc PR can change. This narrows it to checks we actually control.

- **Skip two Mintlify-only failures** via `agent-docs.config.yml`:
  - `content-start-position` — Mintlify's nav/sidebar/TOC convert into markdown and push real content past the 50% mark regardless of how the `.mdx` is written.
  - `llms-txt-directive-html` — Mintlify places the `llms.txt` directive in the page footer; cannot be moved from this repo.
- **Strip Mintlify chrome before parity comparison** — 10 CSS selectors (`#header`, `#footer`, `#sidebar`, `#navbar`, `#table-of-contents`, etc.) pulled from the live rendered DOM. The `markdown-content-parity` check now compares main content to main content instead of flagging sidebar leakage.
- **Target the canonical URL** — `docs.relevanceai.com` 301s cross-host to `relevanceai.com/docs`. Pointing CI at the canonical URL kills the cross-host redirect warning and ensures all checks operate on same-origin content.
- **Make the check reproducible** — `samplingStrategy: deterministic` so the same URLs are sampled every run, no more flaky warn/fail flipping. `afdocs@0.18.7` pinned so output cannot silently change. Node 22 set to match the package engine requirement.

## What still warns (kept intentionally)

- `llms-txt-valid` — Mintlify's auto-generated `llms.txt` is missing a blockquote summary at the top. Kept visible to nudge us to ask Mintlify about it.
- `markdown-content-parity` — Some pages show small (<20%) content diffs, likely Supademo iframes or callouts rendering slightly differently between `.md` and HTML. Worth occasional review but not blocking.

## What still passes (real PR-level signal)

- `markdown-url-support`, `content-negotiation` — the `.md` mirror works
- `llms-txt-coverage`, `llms-txt-links-resolve` — new pages get added to llms.txt and resolve
- `markdown-code-fence-validity` — unterminated code blocks
- `tabbed-content-serialization`, `section-header-quality`
- `http-status-codes`, `redirect-behavior`
- `page-size-html`, `page-size-markdown` — flags a page that has grown too big for agent truncation
- `rendering-strategy`, `cache-header-hygiene`, `auth-gate-detection`

## Local run

| | before | after |
|---|---|---|
| passed | 17 | 18 |
| warnings | 4 | 2 |
| failed | 1 | 0 |
| skipped | 1 | 3 |

## Test plan

- [ ] CI runs on this PR and produces an `afdocs check` job
- [ ] Job output shows 0 failures and the two intentional skips (`content-start-position`, `llms-txt-directive-html`)
- [ ] `markdown-content-parity` no longer flags pages where the only diff is Mintlify chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)