### PR TITLE
fix(style): broaden sidebar selector to match nav and div

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ main > div {
 }
 
 /* Pull left sidebar slightly away from edge */
-div#sidebar {
+#sidebar {
   left: 2.5rem !important;
   padding-left: 0.5rem !important;
 }


### PR DESCRIPTION
## Summary
- Mintlify's latest CLI renders the docs sidebar wrapper as `<nav id="sidebar">` instead of `<div id="sidebar">`.
- The existing `div#sidebar` rule in `style.css` silently no-ops against the new markup, leaving the sidebar drifting away from the viewport edge in `mintlify dev`.
- Dropping the tag qualifier (`#sidebar`) keeps the rule working on both the current prod build (`<div>`) and the upcoming `<nav>` build — so this is also a proactive fix for the next prod deploy.

## Test plan
- [ ] `mintlify dev` — sidebar sits 2.5rem from the viewport edge (matches prod).
- [ ] Confirm prod styling is unchanged after deploy (selector still matches `<div>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)