### PR TITLE
docs: consolidated filesystem sync trigger docs (agents + workforces)

### DIFF
--- a/build/agents/build-your-agent/agent-triggers/filesystem-sync.mdx
+++ b/build/agents/build-your-agent/agent-triggers/filesystem-sync.mdx
@@ -1,0 +1,70 @@
+---
+title: 'Filesystem sync triggers'
+description: 'Trigger an agent automatically when files are written to your project memory or personal files volume'
+sidebarTitle: 'Filesystem sync'
+---
+
+Filesystem sync triggers watch for file writes in your project's shared memory volume or your personal files volume, then automatically send the file's metadata and content to a designated agent. This lets you build agents that react to file activity without polling or manual input.
+
+## How it works
+
+When a file is written to a watched volume, the trigger fires and sends the following to your agent as a message:
+
+- File metadata (name, path, size, last modified time)
+- File content, up to 100KB for text files
+
+If the same file is written to multiple times, each subsequent write continues the same conversation thread rather than opening a new one. This keeps all activity for a single file in a coherent conversation history.
+
+## Setting up a filesystem sync trigger
+
+1. Navigate to your agent and click **Triggers** in the sidebar
+2. Click **Add trigger**
+3. Select **Filesystem sync** from the available options
+4. Choose the volume to watch:
+   - **Shared memory volume** — files stored in your project's shared memory, accessible to all project members
+   - **Personal files volume** — files stored in your own personal files area
+5. Optionally configure glob patterns to filter which files trigger the sync (see [Filtering files with glob patterns](#filtering-files-with-glob-patterns))
+6. Save the trigger
+
+## Filtering files with glob patterns
+
+By default, any file write to the watched volume triggers the sync. You can narrow this down using glob patterns.
+
+- **Include patterns** — only files matching these patterns trigger the sync (e.g., `**/*.pdf` to watch only PDF files)
+- **Exclude patterns** — files matching these patterns are ignored even if they also match an include pattern (e.g., `**/tmp/**` to skip temporary files)
+
+If both include and exclude patterns are configured, a file must match an include pattern and not match any exclude pattern to trigger the sync.
+
+<Accordion title="Glob pattern examples">
+| Pattern | Matches |
+| --- | --- |
+| `**/*.csv` | Any CSV file in any subfolder |
+| `reports/**` | All files inside a `reports/` directory |
+| `**/tmp/**` | Any file inside a `tmp/` directory |
+| `invoices/2025-*.pdf` | PDF files in `invoices/` whose names start with `2025-` |
+</Accordion>
+
+## Access controls
+
+- **Shared memory volume**: only file writes made by the user who created the sync trigger cause the sync to fire. Writes by other project members do not trigger it.
+- **Personal files volume**: only the owner of the personal files volume can create a sync on it, and only their own writes trigger the sync.
+
+## Frequently asked questions (FAQs)
+
+<AccordionGroup>
+  <Accordion title="What happens when the same file is written to multiple times?">
+    Each write to the same file appends a new message to the existing conversation thread for that file. This keeps all activity related to a single file in one continuous thread rather than creating separate conversations.
+  </Accordion>
+  <Accordion title="Is there a file size limit?">
+    Text file content is sent to the agent up to 100KB per file write. Files larger than 100KB will have their content truncated; file metadata is always sent in full regardless of file size.
+  </Accordion>
+  <Accordion title="Can other team members' file writes trigger my sync?">
+    No. Only file writes made by the user who created the sync trigger cause it to fire, even when watching the shared memory volume.
+  </Accordion>
+  <Accordion title="Can I watch both volumes with a single trigger?">
+    No. Each filesystem sync trigger watches one volume. Create a separate trigger for each volume if you need to watch both.
+  </Accordion>
+  <Accordion title="Do glob patterns affect the exclude list independently?">
+    Yes. If you configure both include and exclude patterns, a file triggers the sync only when it matches at least one include pattern and does not match any exclude pattern. Exclude patterns always take precedence.
+  </Accordion>
+</AccordionGroup>

--- a/build/agents/build-your-agent/triggers.mdx
+++ b/build/agents/build-your-agent/triggers.mdx
@@ -88,6 +88,12 @@ Connect to custom webhooks, APIs, and SDKs to trigger your Agent programmaticall
   <Card title="Tools as Triggers" href="/build/agents/build-your-agent/agent-triggers/tools-as-triggers">Use a specific Tool to trigger your Agent.</Card>
 </Columns>
 
+### Filesystem sync triggers
+
+Watch for file writes in your project's shared memory volume or personal files volume and send file content to your Agent automatically.
+
+<Card title="Filesystem sync" href="/build/agents/build-your-agent/agent-triggers/filesystem-sync">Trigger your Agent when files are written to a watched volume.</Card>
+
 ## Choosing the right trigger
 
 | I want to... | Use this trigger |
@@ -99,6 +105,7 @@ Connect to custom webhooks, APIs, and SDKs to trigger your Agent programmaticall
 | Receive data from my own app or website | **Webhook Trigger** |
 | Trigger my agent from code I control | **SDK & API Triggers** |
 | Combine data from multiple sources before triggering | **Tools as Triggers** |
+| React to files written to a shared or personal volume | **Filesystem Sync Triggers** |
 
 ## Frequently asked questions (FAQs)
 

--- a/build/workforces/build-an-ai-workforce/add-triggers.mdx
+++ b/build/workforces/build-an-ai-workforce/add-triggers.mdx
@@ -40,6 +40,16 @@ Use recurring schedules for:
 - Monthly analytics and summaries
 - Periodic system checks and maintenance tasks
 
+#### Filesystem sync triggers
+
+Filesystem sync triggers automatically activate agents when files change in filesystem volumes. You can monitor an entire volume or use glob patterns to include or exclude specific files and folders, giving you precise control over what changes trigger your agents.
+
+Filesystem sync triggers are useful for:
+- Processing new documents as they're uploaded to a volume
+- Monitoring specific folders for file additions or modifications
+- Automating workflows based on file updates
+- Triggering analysis when reports or data files are generated
+
 #### External Triggers (Zapier)
 
 External triggers like Zapier are configured and managed outside of Relevance AI. In Zapier, you can use the "Message Workforce" event to send data to your Workforce whenever a Zap fires — connecting your Workforce to any app or service that Zapier supports without needing a native integration in Relevance AI.
@@ -150,6 +160,25 @@ minute hour day-of-month month day-of-week year
 
 <Note>
 AWS EventBridge cron expressions use 6 fields, unlike traditional Unix cron which uses 5 fields. Always include the year field, and use `?` for either day-of-month or day-of-week when specifying the other.
+</Note>
+
+### Filesystem sync trigger configuration
+
+To configure a filesystem sync trigger:
+
+1. Select the filesystem sync trigger in your workspace.
+2. Choose the filesystem volume you want to monitor.
+3. Optionally, configure **include patterns** to watch only specific files. Examples:
+   - `**/*.pdf` — all PDF files in the volume
+   - `/docs/**` — all files in the `/docs` folder
+4. Optionally, configure **exclude patterns** to ignore certain files. Examples:
+   - `**/temp/**` — ignore files in any `temp` folder
+   - `**/*.tmp` — ignore temporary files
+5. Connect the trigger to the agent that should process file changes.
+6. Test the configuration by adding or modifying a file in the monitored volume.
+
+<Note>
+Include and exclude patterns use glob syntax. If no include pattern is specified, the trigger watches all files in the volume. Exclude patterns take precedence over include patterns.
 </Note>
 
 ## Pausing triggers

--- a/build/workforces/workforce-features/trigger-to-agent-configuration.mdx
+++ b/build/workforces/workforce-features/trigger-to-agent-configuration.mdx
@@ -15,6 +15,7 @@ When connecting triggers to agents, you can utilize several trigger types:
 - **Manual Triggers**: Allow you to manually initiate an agent through the Task View interface
 - **Recurring Schedule Triggers**: Activate agents at predetermined times or intervals using simple schedules (daily, weekly, monthly) or advanced cron expressions for precise timing control
 - **Integration Triggers**: Connect external services (like email, Slack, or CRM systems) to automatically activate agents when specific events occur
+- **Filesystem Sync Triggers**: Monitor filesystem volumes for file changes and automatically activate agents when files are added, modified, or deleted. Supports include/exclude patterns for precise control over which files trigger activation.
 
 <Note>
 For detailed information on configuring recurring schedules and cron expressions, see [Add Triggers](/build/workforces/build-an-ai-workforce/add-triggers).

--- a/docs.json
+++ b/docs.json
@@ -117,7 +117,8 @@
                       "build/agents/build-your-agent/agent-triggers/scheduled-triggers",
                       "build/agents/build-your-agent/agent-triggers/custom-webhook",
                       "build/agents/build-your-agent/agent-triggers/sdk-and-api-triggers",
-                      "build/agents/build-your-agent/agent-triggers/tools-as-triggers"
+                      "build/agents/build-your-agent/agent-triggers/tools-as-triggers",
+                      "build/agents/build-your-agent/agent-triggers/filesystem-sync"
                     ]
                   },
                   {


### PR DESCRIPTION
This PR consolidates 2 drafter PRs that both document the **filesystem sync trigger** feature, in two different surfaces. Opened as draft for review before the source PRs are closed.

## Source PRs (being closed in favor of this one)
- #613 — [TSP-1227](https://linear.app/relevance/issue/TSP-1227): filesystem sync trigger docs for **agents**
- #631 — [TSP-1245](https://linear.app/relevance/issue/TSP-1245): filesystem sync trigger docs for **workforces**

## Why consolidated
Both PRs document the same feature — filesystem sync triggers — just from the agent side (#613) and the workforce side (#631). Shipping them together keeps the terminology, glob-pattern examples, and behavior notes consistent across the two trigger surfaces instead of drifting apart in separate merges.

## Changes by source PR

### #613 — TSP-1227 (agents)
- New page `build/agents/build-your-agent/agent-triggers/filesystem-sync.mdx` covering watched volumes (shared memory vs personal files), glob pattern filtering, the 100KB content limit, conversation threading, and access controls.
- Updates `triggers.mdx` overview to include filesystem sync in the trigger types section and decision table.
- Adds the new page to `docs.json` under Trigger Types.

### #631 — TSP-1245 (workforces)
- Adds a **Filesystem sync triggers** section to `build/workforces/build-an-ai-workforce/add-triggers.mdx` — overview, use cases, and a numbered configuration walkthrough with glob pattern examples.
- Adds the filesystem sync trigger entry to the types list in `trigger-to-agent-configuration.mdx`.

## Reconciliation note
`docs.json` was rebuilt on top of current `main` (the agent-triggers nav group had been reorganized and `sdk-and-api-triggers` renamed to `api-trigger` since these branches forked), so the only nav change here is the single new `filesystem-sync` entry.
