### PR TITLE
docs: consolidated Inventor docs (page, credit counter, Chats)

### DIFF
--- a/admin/subscriptions/plans.mdx
+++ b/admin/subscriptions/plans.mdx
@@ -95,6 +95,10 @@ description: "Understand different plans at Relevance AI, and learn how to manag
     2. Click the number next to 'Credits used'
     3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
 
+    <Note>
+      If you're building an agent with Inventor, the Inventor sidebar shows a real-time credit counter for credits used during that session. See [Inventor](/build/agents/inventor#credit-usage-in-the-inventor-sidebar) for details.
+    </Note>
+
     ### How many Vendor Credits and Actions do I have left?
 
     <img
@@ -321,6 +325,10 @@ description: "Understand different plans at Relevance AI, and learn how to manag
     1. First, access the run of your Agent you want to view credits on, on the Run screen
     2. Click the number next to 'Credits used'
     3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
+
+    <Note>
+      If you're building an agent with Inventor, the Inventor sidebar shows a real-time credit counter for credits used during that session. See [Inventor](/build/agents/inventor#credit-usage-in-the-inventor-sidebar) for details.
+    </Note>
 
     ## Monitoring concurrency usage
 

--- a/build/agents/create-an-agent.mdx
+++ b/build/agents/create-an-agent.mdx
@@ -45,6 +45,22 @@ The fastest way to get started. Describe what you need and we'll generate a work
 5. Review the generated Agent — Inventor will set up the prompt and suggest Tools
 6. Connect any integrations your Tools need (e.g. Gmail, HubSpot, LinkedIn) in the Tools section of the Agent builder, or [add integrations](/integrations/add-integrations) from the sidebar
 
+### Managing your Inventor conversations
+
+Inventor saves each conversation as a session automatically. By default, opening the Inventor drawer starts a new chat, but all past sessions are accessible via the **Chats** dropdown in the drawer header.
+
+To return to a previous session:
+
+1. Open the Inventor drawer on an agent page
+2. Click the **Chats** dropdown in the drawer header
+3. Browse or search your past sessions, then select one to resume it
+
+{/* TODO: Add screenshot of the Chats dropdown in the Inventor drawer header */}
+
+<Info>
+Closing the drawer or refreshing the page does not delete your conversation history — sessions persist and can be resumed at any time.
+</Info>
+
 <Tip>
 Best when you know what you want and can describe it clearly. Great for getting a concept off the ground quickly — Inventor handles the setup, you make the tweaks.
 </Tip>

--- a/build/agents/inventor.mdx
+++ b/build/agents/inventor.mdx
@@ -1,0 +1,75 @@
+---
+title: "Inventor"
+sidebarTitle: "Inventor"
+description: "Inventor is Relevance AI's AI-powered agent and tool builder. Describe what you want to build and Inventor generates a working agent or tool for you."
+---
+
+Inventor generates agents and tools from natural language descriptions. You encounter it when creating a new agent (the **Invent** option) or a new tool — it opens a sidebar where you describe what you want, and Inventor sets up the configuration for you.
+
+## How Inventor works
+
+When you select **Invent** during agent or tool creation, a sidebar opens on the right side of the screen. Type a description of what you want to build and Inventor generates the agent or tool based on your input.
+
+For agents, Inventor configures the prompt and suggests relevant tools. For tools, it builds out the steps and logic of the tool. You can then review and adjust anything before saving.
+
+**Tips for effective descriptions:**
+
+- Be specific about the task, expected output, and any integrations the agent should use
+- Include the type of input it will receive (e.g. a company name, a URL, a list of contacts)
+- Mention how it should handle edge cases if you have specific requirements
+
+**Example:** *"Create an agent that researches a company before a sales call. It should use web search to find recent news, funding, and key contacts, then output a one-page brief with company overview, decision makers, and talking points."*
+
+After Inventor generates the initial configuration, you can continue the conversation in the sidebar to refine it — ask it to add a tool, adjust the prompt, or change how the agent behaves.
+
+## Credit usage in the Inventor sidebar
+
+While using Inventor, the sidebar displays a real-time credit counter showing how many credits you've used during the session. The counter shows "X credits used" with a coins icon, and updates each time you interact with the AI — for example, when generating an agent, requesting adjustments, or asking follow-up questions.
+
+Each AI interaction in Inventor consumes credits. This counter is specific to your current Inventor session and is separate from the organization-wide credit counter in the bottom-left of the platform, which shows your remaining balance for the billing period.
+
+For details on managing your credit balance and monitoring usage, see [Plans and credits](/admin/subscriptions/plans).
+
+## Feedback and bug reporting
+
+Inventor includes built-in feedback tools to help improve its performance over time.
+
+### Thumbs up and thumbs down
+
+Each AI message in the Inventor sidebar has thumbs up and thumbs down buttons. Use these to rate Inventor's responses:
+
+- **Thumbs up** — the response was accurate and helpful
+- **Thumbs down** — the response was incorrect, unhelpful, or the generated agent/tool didn't match what you described
+
+These ratings are used to improve Inventor's output quality.
+
+### Reporting issues with thumbs down
+
+When you click thumbs down, a popup appears where you can describe the problem in detail and submit a bug report directly to the Relevance AI team. You don't need to leave the interface or send a separate email.
+
+Useful details to include in a bug report:
+
+- What you asked Inventor to build
+- What it generated
+- What was wrong or missing
+- What you expected instead
+
+### Automatic failure detection
+
+Inventor monitors conversations for repeated failures. If it detects that a conversation is consistently not producing useful results, it automatically files a bug report — up to two times per conversation. This helps the team identify issues even when users don't submit manual reports.
+
+## When to use Inventor
+
+Inventor works best when:
+
+- You know what you want and can describe it in plain language
+- You want a working starting point quickly and plan to refine it afterward
+- You're building a tool or agent for the first time and want guidance on structure
+
+For more complex agents with specific workflow requirements, you can start with Inventor and then adjust the configuration manually in the agent builder.
+
+## Related pages
+
+- [Create an agent](/build/agents/create-an-agent) — the creation flow where you choose Inventor or other options
+- [Plans and credits](/admin/subscriptions/plans) — manage your credit balance and monitor usage
+- [Support](/get-started/support) — contact the team directly for issues not covered by in-app bug reporting

--- a/docs.json
+++ b/docs.json
@@ -89,6 +89,7 @@
             "group": "Agents",
             "pages": [
               "build/agents/create-an-agent",
+              "build/agents/inventor",
               {
                 "group": "Build an Agent",
                 "pages": [

--- a/get-started/quick-start-guide.mdx
+++ b/get-started/quick-start-guide.mdx
@@ -49,6 +49,8 @@ The fastest way to get started. Describe what you need and we'll generate a work
 5. Review the generated agent — Inventor will set up the prompt and suggest tools
 6. Connect any integrations your tools need (e.g. Gmail, HubSpot, LinkedIn) in the Tools section of the Agent builder, or [add integrations](/integrations/add-integrations) from the sidebar
 
+Inventor saves each conversation as a session — use the **Chats** dropdown in the drawer header to browse and return to past sessions. See [Managing your Inventor conversations](/build/agents/create-an-agent#managing-your-inventor-conversations) for details.
+
 <Tip>
 Best when you know what you want and can describe it clearly. Great for getting a concept off the ground quickly — Inventor handles the setup, you make the tweaks.
 </Tip>


### PR DESCRIPTION
This PR consolidates the Inventor documentation work. Opened as draft for review before the source PRs are closed.

## Source PRs (being closed in favor of this one)
- #607 — consolidated Inventor docs (already a draft merge of #594 + #597)
  - [TSP-1172](https://linear.app/relevance/issue/TSP-1172): new Inventor documentation page
  - [TSP-1171](https://linear.app/relevance/issue/TSP-1171): real-time credit counter in the Inventor interface
- #649 — [TSP-1261](https://linear.app/relevance/issue/TSP-1261): Inventor Chats feature

## Why consolidated
All of this is Inventor-interface documentation landing within days of each other. #607 already created the dedicated `build/agents/inventor.mdx` page and folded the credit-counter content onto it; #649 documents the new Inventor Chats dropdown. Keeping them in one PR avoids a half-documented Inventor page and keeps the nav entry, credit counter, and Chats feature described in one coherent place.

## Changes by source PR

### #607 — TSP-1172 + TSP-1171
- New page `build/agents/inventor.mdx` — overview of the Inventor builder, the real-time credit counter, feedback/bug reporting, and usage guidance.
- `admin/subscriptions/plans.mdx` — Note callouts pointing to the Inventor credit counter section.
- `docs.json` — adds Inventor to the Agents nav group.

### #649 — TSP-1261
- Adds a **Managing your Inventor conversations** section to `build/agents/create-an-agent.mdx` (Chats dropdown, auto-saved sessions, resuming previous sessions).
- Brief mention + link in `get-started/quick-start-guide.mdx`.

## Reconciliation note
`docs.json` was rebuilt on current `main` — the only nav change is the single `build/agents/inventor` entry after `create-an-agent`.

**For reviewer:** #649's Inventor Chats content currently sits on `create-an-agent.mdx`. Now that the dedicated `inventor.mdx` page exists (from #607), consider relocating that section onto `inventor.mdx` for consistency with how the credit counter was handled. Left as-authored here so the move is a deliberate review decision rather than something baked in silently.
