### PR TITLE
docs: consolidated Microsoft Teams outreach + conversation docs

### DIFF
--- a/integrations/popular-integrations/microsoft-teams.mdx
+++ b/integrations/popular-integrations/microsoft-teams.mdx
@@ -196,7 +196,7 @@ Once a trigger fires, the agent responds directly inside Teams with the followin
     Agent replies are threaded in the channel. Conversation threads stay active for 30 minutes.
   </Card>
   <Card title="Adaptive Cards" icon="table-layout">
-    Responses are delivered as Microsoft Adaptive Cards — rich, interactive messages inside Teams. Each card includes a text input and a **Send** button that users click to reply, continuing the conversation without needing to @mention the bot again.
+    Responses are delivered as Microsoft Adaptive Cards — rich, interactive messages inside Teams.
   </Card>
   <Card title="Typing indicator" icon="ellipsis">
     Teams displays a typing indicator while the agent is processing a response.

--- a/integrations/popular-integrations/microsoft-teams.mdx
+++ b/integrations/popular-integrations/microsoft-teams.mdx
@@ -180,7 +180,7 @@ Once a trigger fires, the agent responds directly inside Teams with the followin
     Agent replies are threaded in the channel. Conversation threads stay active for 30 minutes.
   </Card>
   <Card title="Adaptive Cards" icon="table-layout">
-    Responses are delivered as Microsoft Adaptive Cards — rich, interactive messages inside Teams.
+    Responses are delivered as Microsoft Adaptive Cards — rich, interactive messages inside Teams. Each card includes a text input and a **Send** button that users click to reply, continuing the conversation without needing to @mention the bot again.
   </Card>
   <Card title="Typing indicator" icon="ellipsis">
     Teams displays a typing indicator while the agent is processing a response.
@@ -189,7 +189,7 @@ Once a trigger fires, the agent responds directly inside Teams with the followin
     Agents can receive and process inline images, pasted screenshots, and uploaded files (PDFs, documents, images) from Teams conversations.
   </Card>
   <Card title="Proactive messages" icon="paper-plane">
-    Agents can send direct messages to users without the user initiating first.
+    Agents can proactively initiate conversations in Teams DMs without waiting for user input first. Context is maintained across the full conversation, enabling back-and-forth exchanges after the initial outreach.
   </Card>
   <Card title="Workforce triggers" icon="users-gear">
     Teams messages can trigger an entire workforce, not just an individual agent.
@@ -197,6 +197,26 @@ Once a trigger fires, the agent responds directly inside Teams with the followin
 </CardGroup>
 
 <Note>Messages that contain only attachments with no text will show a "[N attachments]" indicator to the agent.</Note>
+
+### Two-way conversations
+
+When an agent sends a message in Teams, it arrives as an Adaptive Card with a text input and a **Send** button. Users type their reply directly in the card and click **Send** to continue the conversation. The agent receives the reply with full context of the prior exchange — no @mentions needed.
+
+Conversation context is maintained automatically across multiple message exchanges within the same thread, so users can have a natural back-and-forth with the agent without any re-initialization.
+
+### Proactive DM conversations
+
+Agents can initiate conversations by sending a direct message to a user in Teams without waiting for the user to reach out first. When the user responds, the agent picks up the conversation with full context intact, allowing multi-turn exchanges that continue naturally from the opening message.
+
+This enables outreach workflows where an agent contacts a user, the user replies, and the agent continues the conversation — all within a DM thread in Teams.
+
+### Outreach-only mode
+
+Outreach-only is a trigger mode where the Teams trigger responds only to replies within conversations the agent started. It does not respond to new root-level messages that users send to the bot directly.
+
+This is the right choice when an agent is doing outreach — for example, proactively DMing a group of users and following up on their responses — and you don't want it to act on unrelated inbound messages in the same channel or chat.
+
+To enable this mode, open your trigger settings and set the trigger mode to **Outreach only**. The trigger will then watch only for replies to threads or DMs that the agent opened, leaving all other conversations unaffected.
 
 ## Tool steps for Microsoft Teams
 

--- a/integrations/popular-integrations/microsoft-teams.mdx
+++ b/integrations/popular-integrations/microsoft-teams.mdx
@@ -171,6 +171,22 @@ The Relevance AI app is available on the Microsoft Teams marketplace. Users can 
 
 <Tip>Set tool permissions to "approval mode" initially so your agent asks before sending messages. Switch to autopilot once you're confident.</Tip>
 
+### Advanced trigger settings
+
+#### Outreach replies only
+
+Enable this toggle to restrict the agent to responding only to replies to messages it previously sent in the channel, rather than all new messages.
+
+This is useful for outreach workflows where the agent sends messages to users and needs to follow up only with those who respond. Rather than monitoring all channel activity, the agent stays focused on conversations it initiated.
+
+**To enable:**
+1. Open your Microsoft Teams trigger settings
+2. Locate the **Outreach replies only** toggle
+3. Toggle it on
+4. Save your configuration
+
+When enabled, the trigger subtitle changes to **"On replies to outreach messages"**. The agent triggers only when a user replies to a message the agent itself sent — new messages posted by other users will not activate it.
+
 ### How triggered conversations work
 
 Once a trigger fires, the agent responds directly inside Teams with the following capabilities:

--- a/integrations/popular-integrations/microsoft-teams.mdx
+++ b/integrations/popular-integrations/microsoft-teams.mdx
@@ -214,26 +214,6 @@ Once a trigger fires, the agent responds directly inside Teams with the followin
 
 <Note>Messages that contain only attachments with no text will show a "[N attachments]" indicator to the agent.</Note>
 
-### Two-way conversations
-
-When an agent sends a message in Teams, it arrives as an Adaptive Card with a text input and a **Send** button. Users type their reply directly in the card and click **Send** to continue the conversation. The agent receives the reply with full context of the prior exchange — no @mentions needed.
-
-Conversation context is maintained automatically across multiple message exchanges within the same thread, so users can have a natural back-and-forth with the agent without any re-initialization.
-
-### Proactive DM conversations
-
-Agents can initiate conversations by sending a direct message to a user in Teams without waiting for the user to reach out first. When the user responds, the agent picks up the conversation with full context intact, allowing multi-turn exchanges that continue naturally from the opening message.
-
-This enables outreach workflows where an agent contacts a user, the user replies, and the agent continues the conversation — all within a DM thread in Teams.
-
-### Outreach-only mode
-
-Outreach-only is a trigger mode where the Teams trigger responds only to replies within conversations the agent started. It does not respond to new root-level messages that users send to the bot directly.
-
-This is the right choice when an agent is doing outreach — for example, proactively DMing a group of users and following up on their responses — and you don't want it to act on unrelated inbound messages in the same channel or chat.
-
-To enable this mode, open your trigger settings and set the trigger mode to **Outreach only**. The trigger will then watch only for replies to threads or DMs that the agent opened, leaving all other conversations unaffected.
-
 ## Tool steps for Microsoft Teams
 
 <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>


### PR DESCRIPTION
This PR consolidates 2 drafter PRs that both document **Microsoft Teams trigger / conversation behavior** and overlap heavily on the same page. Opened as draft for review before the source PRs are closed.

## Source PRs (being closed in favor of this one)
- #646 — [TSP-1258](https://linear.app/relevance/issue/TSP-1258): Teams two-way conversations and outreach-only mode
- #648 — [TSP-1260](https://linear.app/relevance/issue/TSP-1260): "Outreach replies only" trigger toggle (product PR #14979)

## Why consolidated
Both PRs edit `integrations/popular-integrations/microsoft-teams.mdx` and both document the **same outreach feature** plus the Adaptive Card / two-way conversation flow. Shipped separately they produced duplicate, slightly contradictory sections on one page. Consolidating lets the page describe each behavior exactly once.

## Changes by source PR

### #648 — TSP-1260
- Adds **Advanced trigger settings → Outreach replies only** to the Teams page: what the setting does, how to enable it, and the resulting subtitle change ("On replies to outreach messages").

### #646 — TSP-1258
- Enriches the **Adaptive Cards** card (text input + **Send** button, reply without re-@mentioning) and the **Proactive messages** card (context maintained across the conversation).
- Originally also added standalone **Two-way conversations**, **Proactive DM conversations**, and **Outreach-only mode** subsections.

## Reconciliation note
- Kept #648's concrete "Outreach replies only" section and #646's card enrichments.
- **Dropped #646's three standalone subsections** — "Two-way conversations" and "Proactive DM conversations" restated the now-enriched cards, and "Outreach-only mode" described the same feature as #648's section.

> [!NOTE]
> **Verified:** the two drafts described the outreach feature differently (#648 "toggle" vs #646 "trigger mode"). Confirmed against the code — it's a **toggle** ("Outreach replies only"), and the subtitle string "On replies to outreach messages" is exact (product PR #14979; `triggerSubtitles.ts`). #648's wording, kept here, is correct.
