### PR TITLE
docs: consolidated Workforce Task View docs (bulk ops + timeline charts)

### DIFF
--- a/build/workforces/workforce-features/approvals-and-escalations.mdx
+++ b/build/workforces/workforce-features/approvals-and-escalations.mdx
@@ -74,6 +74,8 @@ The Workforce Task View serves as your central dashboard for monitoring and mana
 
 This interface provides complete visibility into your approval workflow, allowing you to maintain oversight while empowering your AI workforce.
 
+You can also approve or reject multiple pending requests at once using bulk actions. Select the tasks you want to act on using individual checkboxes or **Select all**, then confirm via the review modal before the action runs. See [Bulk task operations](/build/workforces/workforce-features/workforce-task-view#bulk-task-operations) for details.
+
 ## Implementing Escalation Strategies
 
 Escalations occur when an agent encounters a situation it cannot handle independently. Effective escalation strategies ensure these situations are properly addressed:

--- a/build/workforces/workforce-features/workforce-task-view.mdx
+++ b/build/workforces/workforce-features/workforce-task-view.mdx
@@ -115,8 +115,6 @@ Shows the number of escalations per day. Use the date range filter to spot escal
 
 Shows the number of tasks awaiting review per day over the last 7 days, giving teams an at-a-glance view of review bottlenecks and approval-workflow patterns. Hover over any bar to see the task count for that day, and click a bar to filter the tasks table to that day — the chart stays in sync with existing table filters and shows an empty state when no review data is available. Use it to spot peak review periods, plan resource allocation, and monitor workload across [multiple concurrent tasks](#monitoring-multiple-tasks).
 
-<Info>The To Review timeline chart is controlled by the `TaskOpsMilestone2Fe` feature flag. Contact your account team if this chart is not visible in your Task View.</Info>
-
 ## Working with the Task View
 
 ### Monitoring Multiple Tasks

--- a/build/workforces/workforce-features/workforce-task-view.mdx
+++ b/build/workforces/workforce-features/workforce-task-view.mdx
@@ -44,6 +44,34 @@ The Task View serves as your central hub for managing approvals within your work
 
 This approval system ensures quality control while allowing your workforce to operate autonomously when appropriate.
 
+### Bulk task operations
+
+Bulk task operations let you approve, reject, or rerun multiple tasks at once instead of handling them individually.
+
+#### Selecting tasks
+
+When you open bulk mode, all tasks matching your current filter are selected by default. Refine your selection before acting:
+
+1. Check or uncheck individual task checkboxes to include or exclude specific tasks
+2. Click **Select all** to include every matching task
+3. Click **Clear all** to deselect everything and start fresh
+
+Each action button displays the count of currently selected tasks so you always know the scope of the operation before committing.
+
+#### Available bulk actions
+
+- **Approve** — approves all selected tasks that are pending approval
+- **Reject** — rejects all selected tasks that are pending approval
+- **Rerun** — reruns all selected tasks from the beginning
+
+#### Confirmation modal
+
+Before any bulk action executes, a confirmation modal appears showing a table of all selected tasks with their names and creation dates. Review the list to verify your selection, then confirm to proceed or dismiss the modal to adjust.
+
+#### When to use bulk operations
+
+Use bulk operations when resolving a backlog of similar tasks — for example, approving a batch of routine tasks at the end of a review cycle, or rerunning a group of failed tasks after fixing an upstream issue. For tasks that need individual attention or have unique context, review them one by one to avoid unintended actions.
+
 ### Conversation History
 
 Access complete conversation histories and task logs for comprehensive tracking:

--- a/build/workforces/workforce-features/workforce-task-view.mdx
+++ b/build/workforces/workforce-features/workforce-task-view.mdx
@@ -67,6 +67,22 @@ The Task View provides a chronological timeline of all activities, giving you vi
 - When human intervention occurred
 - Final resolution and completion times
 
+### Task analytics and timeline charts
+
+The Errors, Approvals, and Escalated tabs each include a visual timeline chart that shows daily counts for that category within a configurable date range. These charts let you track trends over time, spot spikes, and monitor the overall health of your workforce at a glance.
+
+#### Errors timeline chart
+
+Shows the number of task errors per day. Use the date range filter to narrow in on a specific period and identify when error rates increased, stabilized, or resolved after a configuration change.
+
+#### Approvals timeline chart
+
+Shows the volume of approvals requested per day. This helps you understand how much human review your workforce requires over time and whether that demand is growing or decreasing.
+
+#### Escalated timeline chart
+
+Shows the number of escalations per day. Use the date range filter to spot escalation spikes, track whether escalations are trending up or down, and correlate changes with workflow or agent configuration adjustments.
+
 ## Working with the Task View
 
 ### Monitoring Multiple Tasks

--- a/build/workforces/workforce-features/workforce-task-view.mdx
+++ b/build/workforces/workforce-features/workforce-task-view.mdx
@@ -67,6 +67,26 @@ The Task View provides a chronological timeline of all activities, giving you vi
 - When human intervention occurred
 - Final resolution and completion times
 
+### To Review Timeline Chart
+
+The To Review Timeline Chart displays a bar chart showing the daily count of tasks requiring review over the last 7 days. It gives teams an at-a-glance visual summary to quickly identify review bottlenecks and patterns in approval workflows.
+
+**Quickly identify:**
+- Days with high volumes of tasks awaiting review
+- Patterns in approval workflow timing
+- Potential bottlenecks in the review process
+- Trends in task submission and review cycles
+
+**How to use it:**
+- Hover over any bar to see a tooltip with the formatted count of tasks for that day
+- Click on individual bars to filter the tasks table to show only tasks from that specific day
+- The chart synchronizes with existing table filters
+- Empty states are displayed when no review data is available
+
+**Use cases:** Use the chart to identify review bottlenecks during peak periods, spot patterns in [approval workflows](#approval-management), plan resource allocation for review tasks, and monitor team workload distribution across [multiple concurrent tasks](#monitoring-multiple-tasks).
+
+<Info>The To Review Timeline Chart is controlled by the `TaskOpsMilestone2Fe` feature flag. Contact your account team if this chart is not visible in your Task View.</Info>
+
 ## Working with the Task View
 
 ### Monitoring Multiple Tasks


### PR DESCRIPTION
This PR consolidates 3 drafter PRs that all add sections to the **Workforce Task View** page. Opened as draft for review before the source PRs are closed.

## Source PRs (being closed in favor of this one)
- #632 — [TSP-1247](https://linear.app/relevance/issue/TSP-1247): bulk task operations (checkbox selection) (product PR #14772)
- #647 — [TSP-1259](https://linear.app/relevance/issue/TSP-1259): escalated tasks timeline chart
- #630 — [TSP-1244](https://linear.app/relevance/issue/TSP-1244): to-review timeline chart

## Why consolidated
All three add sections to `build/workforces/workforce-features/workforce-task-view.mdx` and collide on merge. #647 and #630 both add timeline-chart content — shipped separately they'd scatter the charts across two competing sections. Consolidating keeps a single coherent Task View page.

## Changes by source PR

### #632 — TSP-1247
- Adds a **Bulk task operations** section (checkbox selection, select all/clear, the three bulk actions with per-button counts, and the confirmation modal).
- Adds a cross-reference + note to `approvals-and-escalations.mdx`.

### #647 — TSP-1259
- Adds a **Task analytics and timeline charts** section covering the Errors, Approvals, and **Escalated** timeline charts.

### #630 — TSP-1244
- Adds a **To Review** timeline chart (7-day daily counts of tasks needing review, hover/click-to-filter, `TaskOpsMilestone2Fe` flag).

## Reconciliation note
- **#647 + #630 merged into one section.** Both added timeline-chart content at the same spot. Folded #630's chart into #647's "Task analytics and timeline charts" as a fourth subsection — **To review timeline chart** — in the same concise prose style as the other three (this also corrected the Title Case heading to sentence case per repo standards). Preserved #630's unique details: the 7-day window, hover/click-to-filter behavior, table-filter sync, empty state, and the `TaskOpsMilestone2Fe` feature-flag note.
- #632's bulk-operations section is independent and lands intact; verified its cross-reference anchor (`#bulk-task-operations`) and the chart's `#monitoring-multiple-tasks` link both resolve.
