### PR TITLE
docs: add warning to RBAC page around adding people to assets

### DIFF
--- a/enterprise/rbac.mdx
+++ b/enterprise/rbac.mdx
@@ -181,6 +181,10 @@ Upon asset creation, the creator becomes the admin. An asset can have multiple a
 | View asset outputs              | ✅         | ✅          | ✅          |
 | View asset audit logs           | ✅         | ✅          | ✅          |
 
+<Warning>
+Adding someone as a Member on an agent does not give them access to the agent's tools. If a tool is set to **Only invited**, you must also add that person as a Member on each of those tools, otherwise the tool is silently dropped when they run the agent.
+</Warning>
+
 ----
 
 ## Workforce Permissions


### PR DESCRIPTION
What it says on the tin. Quick warning on RBAC page based on this ticket: https://app.usepylon.com/issues?issueNumber=11367

Adding someone to an Agent in RBAC doesn't automatically add them to the tools. 