### PR TITLE
docs: recommend multiple org admins in Enterprise quick start

### DIFF
--- a/admin/project-management/add-members.mdx
+++ b/admin/project-management/add-members.mdx
@@ -54,7 +54,7 @@ Members in your organization can be assigned the following roles: Admin, Editor,
 </AccordionGroup>
 
 <Tip>
-Assign more than one admin whenever your plan allows it, so access isn't lost if an admin leaves the company or needs to hand over control unexpectedly. Free organizations are limited to a single admin. On Pro, make both users admins if there's any chance one could leave—otherwise the remaining user can't administrate the organization. On Team and Enterprise plans, keep two or more admins.
+Assign more than one admin whenever your plan allows it, so access isn't lost if an admin leaves the company or needs to hand over control unexpectedly. Free organizations are limited to a single user, who is always the admin of their organization. On Pro, you can only add two users to your organization, yourself and another. If you're the admin of your organization and there's a chance you will leave your team and need to hand over access to your fellow user, you should promote them to admin of your organization as well. On Team and Enterprise plans, keep two or more admins.
 </Tip>
 
 <Info>

--- a/admin/project-management/add-members.mdx
+++ b/admin/project-management/add-members.mdx
@@ -54,7 +54,7 @@ Members in your organization can be assigned the following roles: Admin, Editor,
 </AccordionGroup>
 
 <Tip>
-Assign more than one admin whenever your plan allows it. Free organizations can only have a single admin, but on Pro both users should be admins, and on Team and Enterprise plans keep several—so access isn't lost if an admin leaves the company or needs to hand over control unexpectedly.
+Assign more than one admin whenever your plan allows it, so access isn't lost if an admin leaves the company or needs to hand over control unexpectedly. Free organizations are limited to a single admin. On Pro, make both users admins if there's any chance one could leave—otherwise the remaining user can't administrate the organization. On Team and Enterprise plans, keep two or more admins.
 </Tip>
 
 <Info>

--- a/admin/project-management/add-members.mdx
+++ b/admin/project-management/add-members.mdx
@@ -53,6 +53,10 @@ Members in your organization can be assigned the following roles: Admin, Editor,
   </Accordion>
 </AccordionGroup>
 
+<Tip>
+Assign more than one admin whenever your plan allows it. Free organizations can only have a single admin, but on Pro both users should be admins, and on Team and Enterprise plans keep several—so access isn't lost if an admin leaves the company or needs to hand over control unexpectedly.
+</Tip>
+
 <Info>
 For comprehensive permission details including enterprise RBAC controls, see [Role-based access controls](/enterprise/rbac).
 </Info>

--- a/enterprise/quick-start-guide.mdx
+++ b/enterprise/quick-start-guide.mdx
@@ -339,6 +339,10 @@ If you have an Enterprise subscription but don't have access to a feature marked
     
     Assign project Admin roles carefully—typically just one or two people per project who are responsible for managing that project's resources and access. Too many admins create confusion about ownership and accountability.
     
+    **Avoid a single org admin**
+    
+    At the organization level, assign the Admin role to more than one person. Org Admins manage organization users, organization-level settings, org-level API keys and OAuth connections, and project roles—so if your only Admin is unavailable, no one else can manage members or organization-wide settings. Keeping two or more org Admins preserves continuity while still maintaining clear accountability.
+    
     **Regular audits**
     
     Regularly audit permissions during growth phases, especially when teams reorganize or people change roles. The principle of least privilege isn't just about security—it also reduces confusion by ensuring users only see the resources relevant to their work.

--- a/enterprise/rbac.mdx
+++ b/enterprise/rbac.mdx
@@ -79,6 +79,10 @@ New organization members will be given viewer permissions by default. If invited
 | Create projects                                        | ✅         | ✅         | ❌          | ❌          |
 | View organization members / admins                     | ✅         | ✅         | ✅          | ✅          |
 
+<Tip>
+If your only org Admin becomes unavailable, no one else can manage members, organization settings, org-level API keys and OAuth connections, or project roles. Assign the Admin role to more than one person so access isn't lost if someone leaves or needs to hand over control.
+</Tip>
+
 ----
 
 ## Project level controls
@@ -367,4 +371,5 @@ The following is relevant primarily for API users and developers integrating dir
   <Accordion title="I'm on an Enterprise subscription but do not have access to this feature yet. How do I get access?">This feature is gradually being rolled out to Enterprise customers. Please reach out to your sales representative to express your interest in receiving this feature.</Accordion>
   <Accordion title="How do I limit someone to only access Chat?">To limit a user to only access [Relevance Chat](/get-started/chat/introduction), assign them the **Chat** role at the project level. Users with the Chat role are automatically redirected to Chat and cannot access the main web application. They can still interact with agents and have LLM conversations, but will need appropriate asset-level permissions (Member or higher) on specific agents to run them in Chat.</Accordion>
   <Accordion title="Is there a role that allows a user to approve escalations or interact with agent tasks, but not edit the agent?">Yes, assigning a user the Asset Member role for a specific agent allows them to create tasks on the agent, approve/reject escalations, and view outputs, but not edit or delete the agent's configuration.</Accordion>
+  <Accordion title="How many organization admins should I have?">At least two. Besides the Owner, Admin is the only organization role that can manage users, settings, API keys, and project roles, so a single Admin is a continuity risk if they leave or are unavailable. Keeping two or more preserves access while still maintaining clear accountability.</Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Recommend assigning the organization Admin role to more than one person in the Enterprise quick start, so access isn't lost if a sole admin becomes unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)