### PR TITLE
docs: enterprise PII masking, prompt injection detection, and telemetry retention

### DIFF
--- a/admin/security.mdx
+++ b/admin/security.mdx
@@ -131,7 +131,7 @@ We regularly undergo third-party assessments to ensure that we are compliant wit
 
 ### Prompt injection protection
 
-We have multiple controls, including prompt management, escalation, and parameterized inputs to protect you from prompt injection.
+We have multiple controls, including prompt management, escalation, and parameterized inputs to protect you from prompt injection. Enterprise customers can also enable [prompt injection detection](/enterprise/streaming-events#prompt-injection-detection-enterprise-feature), which scans user input for injection attempts and records them on the OTEL traces streamed to your own infrastructure.
 
 ## Vendor & Supply Chain Security
 

--- a/admin/security.mdx
+++ b/admin/security.mdx
@@ -21,11 +21,12 @@ This page provides a security overview of our product and its key features. We a
 
 ### Data retention 
 
-**Default retention policies:**
+#### Default retention policies
+
 - **Agent and tool run logs**: 30 days (free tier). For other tiers, the data is stored until you choose to delete it
 - **API keys**: Fully self-managed. Relevance will store certs, service accounts, API keys etc securely and encrypted
 
-**Enterprise Data Retention:**
+#### Enterprise Data Retention
 
 For Enterprise customers, Relevance AI offers advanced [Data Retention](/enterprise/data-retention) capabilities that allow organizations to automatically manage the lifecycle of sensitive data. This Enterprise feature enables you to:
 
@@ -110,7 +111,7 @@ We regularly undergo third-party assessments to ensure that we are compliant wit
 
 ### Authentication
 
-- We support SSO and MFA supported via your identity provider for Enterprise customers
+- SSO and MFA are supported via your identity provider for Enterprise customers
 - [Role-based access control (RBAC)](/enterprise/rbac) for organizations and projects is available for Enterprise customers
 - [Fine-grained access control (FGA)](/enterprise/asset-controls) is available for Enterprise customers
 
@@ -125,7 +126,7 @@ We regularly undergo third-party assessments to ensure that we are compliant wit
 
 - You control data sources and can pre-scrub for PII
 - Human-in-the-loop escalation and monitoring features are available
-- Governance agents can be built to pro-actively manage Agent security
+- Governance Agents can be built to proactively manage Agent security
 - S3 Audit events can be used to reactively manage Agent security
 - [Visual Data Masking](/build/agents/build-your-agent/agent-settings/visual-data-masking) protects sensitive information in the UI during screen sharing and team reviews
 
@@ -150,11 +151,11 @@ We have multiple controls, including prompt management, escalation, and paramete
 
 ## Self-hosted models that are multi-region
 
-We don't train any models on your data, ever. Similarly, usually when you access API endpoints for LLMs, the processing agreement states that they don't train on that data. We take it one step further and host our own OpenAI models, and open source ones like LAMA and fireworks that we host within our own AWS and Azure environments which are multi-region as well.
+We don't train any models on your data, ever. Similarly, usually when you access API endpoints for LLMs, the processing agreement states that they don't train on that data. We take it one step further and host our own OpenAI models, and open source ones like LLaMA and Fireworks that we host within our own AWS and Azure environments which are multi-region as well.
 
 ## Key features
 
-Relevance AI offers three key features: Tools, Agents, and Data. Each feature has its own data retention and storage policies, which we will explain in detail below.
+Relevance AI offers three key features: Tools, Agents, and Knowledge. Each feature has its own data retention and storage policies, which we will explain in detail below.
 
 ### Tools
 

--- a/admin/security.mdx
+++ b/admin/security.mdx
@@ -39,7 +39,7 @@ For Enterprise customers, Relevance AI offers advanced [Data Retention](/enterpr
 Data Retention is an Enterprise feature that must be enabled by the Relevance AI team. [Learn more about Data Retention →](/enterprise/data-retention)
 </Info>
 
-## Data Residency & Storage
+## Data residency & storage
 
 ### Choose your region
 
@@ -52,7 +52,7 @@ Data is stored in Australia, the US, or the EU/UK, based on your selection at si
 You can choose the region that best suits your needs when setting up your Relevance AI account.
 
 <Note>
-Your organization's region is selected during signup and cannot be changed after your organization is created. If you need to change regions, [contact support](/support) to discuss your options. Learn more about [organization regions and how to identify yours](/admin/project-management/ids#organization-region).
+Your organization's region is selected during signup and cannot be changed after your organization is created. If you need to change regions, [contact support](/get-started/support) to discuss your options. Learn more about [organization regions and how to identify yours](/admin/project-management/ids#organization-region).
 </Note>
 
 ### Tenant isolation
@@ -74,7 +74,7 @@ Your organization's region is selected during signup and cannot be changed after
 - Workstations are configured with encryption by default, data exfiltration prevention and lock when idle
 - Up to date software is enforced to prevent malware
 
-## Security Certifications and Compliance 
+## Security certifications and compliance
 
 ### SOC2 Type II compliant
 
@@ -94,7 +94,7 @@ We offer security questionnaire completion for Enterprise customers. We only sha
 
 We regularly undergo third-party assessments to ensure that we are compliant with the latest security standards. These are performed by independent security firms. Reports are available to Enterprise customers under NDA.
 
-## Encryption & Key Management
+## Encryption & key management
 
 ### Encryption everywhere
 
@@ -106,22 +106,22 @@ We regularly undergo third-party assessments to ensure that we are compliant wit
 - Relevance provides a mechanism to securely store keys
 - Customers must manage the scope of the keys at the underlying integration
 
-## Access Management
+## Access management
 
 ### Authentication
 
 - We support SSO and MFA supported via your identity provider for Enterprise customers
-- [Role-based access control (RBAC)](https://relevanceai.com/docs/enterprise/rbac) for organizations and projects is available for Enterprise customers
-- [Fine-grained access control (FGA)](https://relevanceai.com/docs/enterprise/asset-controls) is available for Enterprise customers
+- [Role-based access control (RBAC)](/enterprise/rbac) for organizations and projects is available for Enterprise customers
+- [Fine-grained access control (FGA)](/enterprise/asset-controls) is available for Enterprise customers
 
 ### Administrative controls
 
 - Fine-grained RBAC and escalation features for sensitive actions is available for Enterprise customers
 - Least-privilege access by default
 
-## AI Agent Security
+## AI Agent security
 
-### Preventing data leaks and monitoring Agent behavior:
+### Preventing data leaks and monitoring Agent behavior
 
 - You control data sources and can pre-scrub for PII
 - Human-in-the-loop escalation and monitoring features are available
@@ -133,14 +133,14 @@ We regularly undergo third-party assessments to ensure that we are compliant wit
 
 We have multiple controls, including prompt management, escalation, and parameterized inputs to protect you from prompt injection. Enterprise customers can also enable [prompt injection detection](/enterprise/streaming-events#prompt-injection-detection-enterprise-feature), which scans user input for injection attempts and records them on the OTEL traces streamed to your own infrastructure.
 
-## Vendor & Supply Chain Security
+## Vendor & supply chain security
 
 ### Third-party risk management
 
 - All subprocessors are listed at https://trust.relevanceai.com/subprocessors
 - We conduct annual reviews and risk assessments for all vendors
 
-## Disaster Recovery & Business Continuity
+## Disaster recovery & business continuity
 
 ### Resilience
 
@@ -152,13 +152,13 @@ We have multiple controls, including prompt management, escalation, and paramete
 
 We don't train any models on your data, ever. Similarly, usually when you access API endpoints for LLMs, the processing agreement states that they don't train on that data. We take it one step further and host our own OpenAI models, and open source ones like LAMA and fireworks that we host within our own AWS and Azure environments which are multi-region as well.
 
-## Key Features
+## Key features
 
 Relevance AI offers three key features: Tools, Agents, and Data. Each feature has its own data retention and storage policies, which we will explain in detail below.
 
 ### Tools
 
-Tools in Relevance AI are powerful workflows that allow you to transform and process input data. It's important to note that neither the input nor the output of these tools is logged by Relevance AI. However, some steps within the tools may require the use of external vendors for processing. For example, LLM steps utilize different vendors depending on the specific model being used.
+Tools in Relevance AI are workflows that transform and process input data. It's important to note that neither the input nor the output of these tools is logged by Relevance AI. However, some steps within the tools may require the use of external vendors for processing. For example, LLM steps utilize different vendors depending on the specific model being used.
 
 ### Agents
 
@@ -168,7 +168,7 @@ Agents in Relevance AI enable conversations and maintain a history of interactio
 
 Knowledge is a feature in Relevance AI that allows you to store data in a table, enabling bulk runs of tools on entire datasets. You have full control over your stored data and can delete it at any time. Similar to agents, your data is stored securely within the region you have selected for your Relevance AI account.
 
-### LLM Models
+### LLM models
 
 If you provide an OpenAI API Key, it will be passed through OpenAI's API service. No data is stored or trained on during this process. You can review the Data Processing Agreement (DPA) on our website for more information.
 

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -144,24 +144,54 @@ To enable Visual Data Masking on a workforce:
 
 Visual Data Masking applies to these UI elements:
 
-- **Agent conversation histories** in the Task View
-- **Workforce task displays** showing agent interactions
-- **Message content** displayed in conversation logs
-- **Tool inputs and outputs** visible in the UI conversation flow
-- **Any front-end conversation data display** in the Relevance AI platform
+<CardGroup cols={2}>
+  <Card title="Agent conversation histories" icon="messages">
+    Conversations shown in the Task View
+  </Card>
+  <Card title="Workforce task displays" icon="list-check">
+    Task views showing agent interactions
+  </Card>
+  <Card title="Message content" icon="comment">
+    Messages displayed in conversation logs
+  </Card>
+  <Card title="Tool inputs and outputs" icon="wrench">
+    Tool data visible in the UI conversation flow
+  </Card>
+  <Card title="Front-end conversation displays" icon="display">
+    Anywhere conversation data appears in the Relevance AI platform UI
+  </Card>
+</CardGroup>
 
 ### What ISN'T masked
 
 Visual Data Masking does NOT apply to:
 
-- **Backend data storage** - Data is stored unmasked in the database
-- **Agent processing** - Agents always work with unmasked, actual data
-- **Tool execution** - Tools receive and process unmasked data
-- **LLM requests** - Language models receive unmasked data for processing
-- **API responses** - Data returned via API is unmasked
-- **Exported message content** - Conversation message bodies in data exports are unmasked. The one exception is the CSV conversation export, which masks the agent name ("Run By") column when Visual Data Masking is enabled
-- **Backend logs** - Internal system logs contain unmasked data
-- **Event streaming** - OTEL events exported to S3 contain unmasked data (unless PII Redaction is enabled)
+<CardGroup cols={2}>
+  <Card title="Backend data storage" icon="database">
+    Data is stored unmasked in the database
+  </Card>
+  <Card title="Agent processing" icon="robot">
+    Agents always work with unmasked, actual data
+  </Card>
+  <Card title="Tool execution" icon="gear">
+    Tools receive and process unmasked data
+  </Card>
+  <Card title="LLM requests" icon="brain">
+    Language models receive unmasked data for processing
+  </Card>
+  <Card title="API responses" icon="code">
+    Data returned via API is unmasked
+  </Card>
+  <Card title="Backend logs" icon="file-lines">
+    Internal system logs contain unmasked data
+  </Card>
+  <Card title="Exported message content" icon="file-export">
+    Conversation message bodies in data exports are unmasked. The one exception is the CSV conversation export, which masks the agent name ("Run By") column when Visual Data Masking is enabled
+  </Card>
+  <Card title="Event streaming" icon="cloud-arrow-up">
+    OTEL events exported to S3 contain unmasked data, unless PII Redaction is enabled
+  </Card>
+</CardGroup>
 
 <Warning>
 Visual Data Masking is a UI-only feature. It does not modify, encrypt, or redact data at the storage or processing level. Backend data remains completely unchanged. For backend data protection, see [PII Redaction](#visual-data-masking-vs-pii-redaction).

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -55,20 +55,12 @@ Enable Visual Data Masking when you need to protect sensitive information from b
 
 Visual Data Masking automatically detects and masks the following types of sensitive information:
 
-<CardGroup cols={2}>
-  <Card title="Email addresses" icon="envelope">
-    Masks email addresses like `user@example.com` → `***@***.com`
-  </Card>
-  <Card title="Phone numbers" icon="phone">
-    Masks phone numbers like `(555) 123-4567` → `***-***-1234`
-  </Card>
-  <Card title="Credit card numbers" icon="credit-card">
-    Masks credit card numbers like `4532 1234 5678 9010` → `****-****-****-9010`
-  </Card>
-  <Card title="Person names" icon="user">
-    Masks person names like `John Smith` → `**** *****`
-  </Card>
-</CardGroup>
+| PII type | Example input | Masked output |
+|----------|---------------|---------------|
+| Email addresses | `user@example.com` | `***@***.com` |
+| Phone numbers | `(555) 123-4567` | `***-***-1234` |
+| Credit card numbers | `4532 1234 5678 9010` | `****-****-****-9010` |
+| Person names | `John Smith` | `**** *****` |
 
 Detection happens automatically in real-time as conversations are displayed in the UI using AI-powered pattern recognition.
 

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -318,7 +318,7 @@ We're actively improving Visual Data Masking based on user feedback. If you enco
   </Card>
 </CardGroup>
 
-## Frequently asked questions
+## Frequently asked questions (FAQs)
 
 <AccordionGroup>
   <Accordion title="Does Visual Data Masking affect agent performance?">

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -159,7 +159,7 @@ Visual Data Masking does NOT apply to:
 - **Tool execution** - Tools receive and process unmasked data
 - **LLM requests** - Language models receive unmasked data for processing
 - **API responses** - Data returned via API is unmasked
-- **Data exports** - Exported data contains unmasked information
+- **Exported message content** - Conversation message bodies in data exports are unmasked. The one exception is the CSV conversation export, which masks the agent name ("Run By") column when Visual Data Masking is enabled
 - **Backend logs** - Internal system logs contain unmasked data
 - **Event streaming** - OTEL events exported to S3 contain unmasked data (unless PII Redaction is enabled)
 
@@ -358,7 +358,7 @@ We're actively improving Visual Data Masking based on user feedback. If you enco
   </Accordion>
 
   <Accordion title="Can I export unmasked data for analysis?">
-    Yes. Visual Data Masking only affects the UI display. Data exports, API responses, and backend storage all contain unmasked data. If you need masked exports, you'll need to implement masking in your export pipeline or use PII Redaction (Enterprise) for S3 event streaming.
+    Yes. Visual Data Masking primarily affects the UI display, so API responses and backend storage always contain unmasked data, and conversation message content in exports is unmasked. The one exception is the CSV conversation export, which masks the agent name ("Run By") column when Visual Data Masking is enabled. If you need broader masking of exported data, implement masking in your export pipeline or use PII Redaction (Enterprise) for S3 event streaming.
   </Accordion>
 
   <Accordion title="Does this protect data sent to LLMs?">

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -181,7 +181,7 @@ Visual Data Masking does NOT apply to:
     Conversation message bodies in data exports are unmasked. The one exception is the CSV conversation export, which masks the agent name ("Run By") column when Visual Data Masking is enabled
   </Card>
   <Card title="Event streaming" icon="cloud-arrow-up">
-    OTEL events exported to S3 contain unmasked data, unless PII Redaction is enabled
+    OTEL events exported to S3 are unmasked, except structured fields like email and IP that are always scrubbed. Unstructured content is scrubbed only when PII Redaction is enabled
   </Card>
 </CardGroup>
 

--- a/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
+++ b/build/agents/build-your-agent/agent-settings/visual-data-masking.mdx
@@ -140,7 +140,7 @@ To enable Visual Data Masking on a workforce:
 
 ## What is and isn't masked
 
-### What IS masked
+### What is masked
 
 Visual Data Masking applies to these UI elements:
 
@@ -162,7 +162,7 @@ Visual Data Masking applies to these UI elements:
   </Card>
 </CardGroup>
 
-### What ISN'T masked
+### What isn't masked
 
 Visual Data Masking does NOT apply to:
 
@@ -240,7 +240,7 @@ Learn more about [PII Redaction for Event Streaming](/enterprise/streaming-event
 
 <Tabs>
   <Tab title="When to enable">
-    ### Enable Visual Data Masking when:
+    ### Enable Visual Data Masking when
 
     - Your agents handle customer PII regularly
     - Multiple team members review agent conversations
@@ -248,14 +248,14 @@ Learn more about [PII Redaction for Event Streaming](/enterprise/streaming-event
     - You need an extra layer of privacy protection in the UI
     - Compliance policies require limiting PII visibility
 
-    ### Consider NOT enabling when:
+    ### Consider not enabling when
 
     - You need to see actual values for debugging or troubleshooting
     - Your agents don't process sensitive information
     - You're the only person accessing the agent
     - Masked values would make conversation review difficult
 
-    ### Important limitations to consider:
+    ### Important limitations to consider
 
     - **Do not rely solely on Visual Data Masking** for critical privacy requirements
     - **Test with sample data** to understand detection accuracy for your use case

--- a/enterprise/data-retention.mdx
+++ b/enterprise/data-retention.mdx
@@ -313,7 +313,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
   <Accordion title="Audit and compliance records" icon="file-lines">
     Consider your audit and compliance requirements when setting retention periods. Some regulations require specific retention periods for audit trails.
     
-    If you use [S3 Event Streaming](/enterprise/streaming-events), those audit logs are stored in your own S3 bucket and are not affected by Data Retention policies in Relevance AI.
+    If you use [S3 Event Streaming](/enterprise/streaming-events), those audit logs and traces are delivered to your own S3 bucket and are not affected by Data Retention policies in Relevance AI. Their retention is governed by your bucket's own lifecycle policy. On the Relevance side, telemetry only passes through a temporary staging bucket that is automatically purged after 30 days.
   </Accordion>
 </AccordionGroup>
 
@@ -355,7 +355,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
   </Accordion>
 
   <Accordion title="Does this affect my S3 Event Streaming data?">
-    No. If you use [S3 Event Streaming](/enterprise/streaming-events), audit logs and events stored in your own S3 bucket are not affected by Data Retention policies in Relevance AI. You control the lifecycle of data in your own S3 bucket.
+    No. If you use [S3 Event Streaming](/enterprise/streaming-events), audit logs and events delivered to your own S3 bucket are not affected by Data Retention policies in Relevance AI. You control the lifecycle of data in your own S3 bucket through its lifecycle policy. On the Relevance side, telemetry only passes through a temporary staging bucket that is automatically purged after 30 days.
   </Accordion>
 
   <Accordion title="Who can configure Data Retention settings?">

--- a/enterprise/data-retention.mdx
+++ b/enterprise/data-retention.mdx
@@ -5,9 +5,7 @@ description: "Control how long sensitive data is stored in your Relevance AI org
 ---
 
 <Warning>
-Data Retention is an Enterprise feature that must be enabled by the Relevance AI team. If you have an Enterprise subscription and would like to use this feature, please contact your sales representative or [reach out to support](/get-started/support).
-
-You will not be able to access this feature if you are not on an Enterprise subscription.
+Data Retention is an Enterprise feature that must be enabled by the Relevance AI team and is not available on other plans. Contact your sales representative or [reach out to support](/get-started/support) to request enablement.
 </Warning>
 
 Data Retention is an Enterprise feature that allows organizations to automatically manage the lifecycle of sensitive data stored in Relevance AI. By configuring retention policies, you can ensure that data is automatically deleted after a specified period, supporting compliance requirements, security best practices, and storage optimization.
@@ -109,9 +107,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 </Note>
 
 <Warning>
-  The Data Retention feature applies to data stored and managed by Relevance AI only. It does not apply to data processed or stored by our subprocessors (third-party service providers).
-
-  For questions about data retention policies for specific subprocessors or integrations, please contact your Account Manager or reach out to our [support team](/get-started/support).
+The Data Retention feature applies only to data stored and managed by Relevance AI, not to data processed or stored by our subprocessors. For questions about subprocessor or integration retention policies, contact your Account Manager or [reach out to support](/get-started/support).
 </Warning>
 
 ---
@@ -161,7 +157,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 </Steps>
 
 <Warning>
-**Data deletion is permanent and cannot be undone.** Once data is deleted through retention policies, it cannot be recovered. Ensure your retention period aligns with your organization's compliance, legal, and operational requirements before enabling this feature.
+Data deletion is permanent and cannot be undone. Once data is deleted through retention policies, it cannot be recovered, so ensure your retention period aligns with your organization's compliance, legal, and operational requirements before enabling this feature.
 </Warning>
 
 ---

--- a/enterprise/data-retention.mdx
+++ b/enterprise/data-retention.mdx
@@ -112,7 +112,7 @@ The Data Retention feature applies only to data stored and managed by Relevance 
 
 ---
 
-## How to Configure Data Retention
+## How to configure Data Retention
 
 <Info>
   To configure Data Retention, you must have an Enterprise subscription, the feature must be enabled by Relevance AI, and you must be an organization admin or owner.
@@ -343,7 +343,7 @@ Data deletion is permanent and cannot be undone. Once data is deleted through re
   </Accordion>
 
   <Accordion title="How do I know what data will be deleted?">
-    Data is deleted based on the conditions outlined in the "What Data Is Covered?" section above. Review those conditions carefully to understand what data is eligible for deletion based on your retention period.
+    Data is deleted based on the conditions outlined in the "What data is covered?" section above. Review those conditions carefully to understand what data is eligible for deletion based on your retention period.
   </Accordion>
 
   <Accordion title="Can I temporarily disable Data Retention?">

--- a/enterprise/data-retention.mdx
+++ b/enterprise/data-retention.mdx
@@ -22,34 +22,34 @@ This feature gives organization admins control over how long different types of 
   />
 </Frame>
 
-## Why Use Data Retention?
+## Why use Data Retention?
 
 <CardGroup cols={2}>
-  <Card title="Compliance & Governance" icon="scale-balanced">
+  <Card title="Compliance & governance" icon="scale-balanced">
     Meet regulatory requirements for data retention limits (GDPR, industry-specific regulations) and demonstrate compliance with data minimization principles
   </Card>
   
-  <Card title="Security & Risk Management" icon="shield-check">
+  <Card title="Security & risk management" icon="shield-check">
     Reduce your organization's data exposure by automatically removing old, potentially sensitive information that's no longer needed
   </Card>
   
-  <Card title="Storage Optimization" icon="database">
+  <Card title="Storage optimization" icon="database">
     Manage storage costs and platform performance by automatically cleaning up historical data that's no longer actively used
   </Card>
   
-  <Card title="Operational Control" icon="gears">
+  <Card title="Operational control" icon="gears">
     Establish consistent data lifecycle policies across your entire organization without manual intervention
   </Card>
 </CardGroup>
 
 ---
 
-## What Data Is Covered?
+## What data is covered?
 
 Data Retention policies apply to four main categories of data in Relevance AI. Each category has specific conditions that determine when data is eligible for deletion.
 
 <AccordionGroup>
-  <Accordion title="Tool Runs & Sync Items" icon="wrench">
+  <Accordion title="Tool runs & sync items" icon="wrench">
     **What's included:**
     - Individual tool execution records
     - Sync items from integrated data sources
@@ -61,7 +61,7 @@ Data Retention policies apply to four main categories of data in Relevance AI. E
     **Example:** If you set a 90-day retention period, any tool run older than 90 days will be automatically deleted.
   </Accordion>
 
-  <Accordion title="Agent Conversations" icon="messages">
+  <Accordion title="Agent conversations" icon="messages">
     **What's included:**
     - Complete conversation threads with agents
     - All messages within conversations
@@ -74,7 +74,7 @@ Data Retention policies apply to four main categories of data in Relevance AI. E
     **Example:** A conversation started 100 days ago with a message added 50 days ago will NOT be deleted if your retention period is 90 days. The conversation is only deleted when both the conversation AND all its messages exceed the retention period.
   </Accordion>
 
-  <Accordion title="Workforce Tasks" icon="list-check">
+  <Accordion title="Workforce tasks" icon="list-check">
     **What's included:**
     - Workforce task records
     - All conversations within workforce tasks
@@ -87,7 +87,7 @@ Data Retention policies apply to four main categories of data in Relevance AI. E
     **Example:** A workforce task from 100 days ago with an associated conversation that has a recent message will NOT be deleted until both the task and all its conversations (including all messages) exceed the retention period.
   </Accordion>
 
-  <Accordion title="Agent, Tool & Workforce Versions" icon="code-branch">
+  <Accordion title="Agent, Tool & Workforce versions" icon="code-branch">
     **What's included:**
     - Historical versions of agents
     - Historical versions of tools
@@ -123,25 +123,25 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 </Info>
 
 <Steps>
-  <Step title="Request Feature Enablement" icon="envelope">
+  <Step title="Request feature enablement" icon="envelope">
     Contact the Relevance AI team to enable Data Retention for your organization. This is not a self-serve feature and must be activated by our team.
     
     Reach out to your sales representative or [contact support](/get-started/support) to request enablement.
   </Step>
 
-  <Step title="Navigate to Data Management" icon="gear">
+  <Step title="Navigate to data management" icon="gear">
     Once enabled, click **"Settings"** in the sidebar, then select **"Manage organization"** to access organization-level settings.
     
     Navigate to the **"Data management"** section where you'll find Data Retention controls.
   </Step>
 
-  <Step title="Create Configuration" icon="plus">
+  <Step title="Create configuration" icon="plus">
     Click **"Create configuration"** to set up your organization's data retention policy.
     
     This opens the configuration interface where you can define your retention settings.
   </Step>
 
-  <Step title="Enable and Set Retention Period" icon="clock">
+  <Step title="Enable and set retention period" icon="clock">
     Toggle the **"Enable"** slider to activate data retention for your organization.
     
     Set your desired **retention period in days**. This determines how long data is kept before being automatically deleted.
@@ -153,7 +153,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
     - 365 days - Annual retention for long-term records
   </Step>
 
-  <Step title="Save Configuration" icon="floppy-disk">
+  <Step title="Save configuration" icon="floppy-disk">
     Click **"Save"** to apply your data retention policy.
     
     The policy takes effect immediately and will begin automatically deleting data that exceeds the retention period.
@@ -166,11 +166,11 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 
 ---
 
-## Use Cases & Compliance Considerations
+## Use cases & compliance considerations
 
 <Tabs>
-  <Tab title="Compliance Requirements" icon="scale-balanced">
-    ### Meeting Regulatory Standards
+  <Tab title="Compliance requirements" icon="scale-balanced">
+    ### Meeting regulatory standards
     
     Data Retention helps organizations comply with various regulatory frameworks that mandate data retention limits:
     
@@ -189,8 +189,8 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
     </Tip>
   </Tab>
   
-  <Tab title="Security Best Practices" icon="shield-check">
-    ### Reducing Data Exposure
+  <Tab title="Security best practices" icon="shield-check">
+    ### Reducing data exposure
     
     Implementing data retention policies reduces your organization's security risk profile:
     
@@ -214,8 +214,8 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
     </Note>
   </Tab>
   
-  <Tab title="Operational Efficiency" icon="gauge-high">
-    ### Optimizing Platform Performance
+  <Tab title="Operational efficiency" icon="gauge-high">
+    ### Optimizing platform performance
     
     Data Retention supports operational efficiency and cost management:
     
@@ -240,8 +240,8 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
     - Aligns storage costs with business value
   </Tab>
   
-  <Tab title="Planning Your Policy" icon="clipboard-list">
-    ### Determining the Right Retention Period
+  <Tab title="Planning your policy" icon="clipboard-list">
+    ### Determining the right retention period
     
     Consider these factors when setting your retention period:
     
@@ -273,7 +273,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 
 ---
 
-## Important Considerations
+## Important considerations
 
 <AccordionGroup>
   <Accordion title="Data deletion is permanent" icon="triangle-exclamation">
@@ -365,14 +365,14 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
 
 ---
 
-## Related Enterprise Features
+## Related Enterprise features
 
 <CardGroup cols={2}>
   <Card title="S3 Event Streaming" icon="database" href="/enterprise/streaming-events">
     Stream audit logs and compliance data to your own S3 bucket for long-term retention
   </Card>
   
-  <Card title="Role-Based Access Controls" icon="shield-halved" href="/enterprise/rbac">
+  <Card title="Role-based access controls" icon="shield-halved" href="/enterprise/rbac">
     Control who can access and manage data with granular permissions
   </Card>
   
@@ -380,7 +380,7 @@ Data Retention policies do not affect knowledge bases, integrations, API keys, o
     Monitor usage patterns to inform your retention policy decisions
   </Card>
   
-  <Card title="Integration Controls" icon="plug" href="/enterprise/integration-controls">
+  <Card title="Integration controls" icon="plug" href="/enterprise/integration-controls">
     Govern which integrations can access your organization's data
   </Card>
 </CardGroup>

--- a/enterprise/streaming-events.mdx
+++ b/enterprise/streaming-events.mdx
@@ -25,6 +25,8 @@ You don't need to run an OTEL collector to use this feature. Events are delivere
 
 <Note>**S3 is currently the only supported destination**. Support for direct OTEL collector endpoints is on our roadmap.</Note>
 
+<Note>Because events are delivered to your own bucket, you control their retention through your bucket's lifecycle policy. On the Relevance side, telemetry only passes through a temporary staging bucket that is automatically purged after 30 days. This is independent of the [Data Retention](/enterprise/data-retention) policy, which governs platform data such as conversations, tool runs, and versions.</Note>
+
 ---
 
 ## Setup
@@ -158,6 +160,27 @@ Before configuring PII redaction, ensure:
 | `score_threshold` | float | No | Minimum confidence level for PII detection (0.0–1.0). Higher values require more confidence |
 
 <Warning>There is currently no self-serve UI to toggle PII redaction. It is configured at the organization level by the Relevance AI team. Contact your Account Manager to have it enabled.</Warning>
+
+---
+
+## Prompt injection detection (Enterprise feature)
+
+Prompt injection detection is an org-level feature that scans incoming user input for prompt injection attempts. When an attempt is detected, the result is recorded on the agent's execution trace so you can monitor and alert on it in your own observability stack.
+
+Detection runs as a post-processing scan that is independent of the underlying LLM model. It flags and records attempts; it does not block or rewrite the user's message.
+
+<Note>Prompt injection detection requires event streaming to be enabled, because results surface only on the OTEL traces delivered to your S3 bucket. It is a contractual Enterprise feature with no self-serve UI — contact your Account Manager to enable it for your organization.</Note>
+
+### Where it surfaces
+
+Detection results are added as attributes on the [`invoke_agent`](#invoke_agent) span:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `relevance_ai.prompt_injection.detected` | boolean | Whether a prompt injection attempt was detected in the user input |
+| `relevance_ai.prompt_injection.confidence` | double | Confidence score for the detection (0.0–1.0) |
+
+These attributes are only present when prompt injection detection is enabled for your organization. Query them in your observability tool the same way you would any other span attribute.
 
 ---
 
@@ -471,6 +494,8 @@ Records a complete agent conversation/invocation.
 | `relevance_ai.agent.escalation.reason` | string | No | Escalation reason |
 | `relevance_ai.agent.escalation.context` | string | No | Escalation context |
 | `relevance_ai.agent.version_id` | string | No | The active version ID of the agent at invocation time. Use this to compare performance across agent versions |
+| `relevance_ai.prompt_injection.detected` | boolean | No | Whether a prompt injection attempt was detected in the user input. Only present when [prompt injection detection](#prompt-injection-detection-enterprise-feature) is enabled |
+| `relevance_ai.prompt_injection.confidence` | double | No | Confidence score (0.0–1.0) for the prompt injection detection. Only present when prompt injection detection is enabled |
 
 ### `chat`
 

--- a/enterprise/streaming-events.mdx
+++ b/enterprise/streaming-events.mdx
@@ -36,7 +36,7 @@ You don't need to run an OTEL collector to use this feature. Events are delivere
 - AWS account with permissions to create S3 buckets and bucket policies
 - Relevance AI Enterprise plan
 
-### 1. Create an S3 Bucket
+### 1. Create an S3 bucket
 
 Create a bucket in the **same AWS region** as your Relevance data:
 
@@ -46,7 +46,7 @@ Create a bucket in the **same AWS region** as your Relevance data:
 | Europe | `eu-west-2` (London) |
 | US | `us-east-1` (N. Virginia) |
 
-### 2. Configure Bucket Policy
+### 2. Configure bucket policy
 
 Add this policy to allow Relevance to write events to your bucket:
 
@@ -75,7 +75,7 @@ Replace:
 - `YOUR_BUCKET_NAME`: Your S3 bucket name
 - `RELEVANCE_EVENT_CONSUMER_ROLE_ARN`: Contact your Relevance team for the region-specific IAM role ARN
 
-### 3. Provide Configuration to Relevance
+### 3. Provide configuration to Relevance
 
 Send your Account Manager or support team:
 
@@ -85,7 +85,7 @@ Send your Account Manager or support team:
 
 ---
 
-## PII Redaction (Enterprise Feature)
+## PII Redaction (Enterprise feature)
 
 PII (Personally Identifiable Information) redaction is an org-level feature that automatically scrubs sensitive information like email addresses, phone numbers, credit card numbers, and names before your event data leaves the platform and is delivered to your S3 destination.
 
@@ -184,7 +184,7 @@ These attributes are only present when prompt injection detection is enabled for
 
 ---
 
-## Delivery Format
+## Delivery format
 
 **Format**: Gzipped JSON following the OpenTelemetry JSON specification.
 
@@ -219,7 +219,7 @@ Audit logs provide a complete record of activity across your organization for se
 }
 ```
 
-### Base Attributes
+### Base attributes
 
 Included on all log records:
 
@@ -233,7 +233,7 @@ Included on all log records:
 | `relevance_ai.ip_address` | string | No | IP address of the request |
 | `relevance_ai.device_info` | string | No | User agent / device information |
 
-### Log Record Properties
+### Log record properties
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -243,9 +243,9 @@ Included on all log records:
 | `body.stringValue` | string | The event name |
 | `attributes` | array | Key-value pairs with base + event attributes |
 
-### Supported Events
+### Supported events
 
-### Agent Events
+### Agent events
 
 **`agent_created`** - Emitted when a new agent is created (from scratch, cloned, or duplicated).
 
@@ -282,7 +282,7 @@ Included on all log records:
 | `relevance_ai.event.agent_id` | string | Yes | ID of the agent being published |
 | `relevance_ai.event.version_id` | string | Yes | ID of the version now live |
 
-### Tool Events
+### Tool events
 
 **`tool_created`** - Emitted when a new tool is created (from scratch or cloned).
 
@@ -313,7 +313,7 @@ Included on all log records:
 | `relevance_ai.event.tool_id` | string | Yes | ID of the tool being published |
 | `relevance_ai.event.version_id` | string | Yes | ID of the version now live |
 
-### Workforce Events
+### Workforce events
 
 **`workforce_created`** - Emitted when a new workforce is created (from scratch, cloned, or duplicated).
 
@@ -344,7 +344,7 @@ Included on all log records:
 | `relevance_ai.event.workforce_id` | string | Yes | ID of the workforce being published |
 | `relevance_ai.event.version_id` | string | No | ID of the version now live |
 
-### Permission Events
+### Permission events
 
 **`project_user_role_updated`** - Emitted when a user's role within a project is updated. This occurs when an admin changes another user's access level in the project settings.
 
@@ -360,7 +360,7 @@ Included on all log records:
 | `relevance_ai.event.target_user_id` | string | Yes | ID of the user whose role was changed |
 | `relevance_ai.event.organization_role` | string | Yes | The new organization role assigned to the user |
 
-### Example Log Record
+### Example log record
 
 ```json
 {
@@ -410,7 +410,7 @@ Traces track execution flows for agents, workforces, and LLM completions. Use tr
 }
 ```
 
-### Resource Attributes
+### Resource attributes
 
 Resource attributes identify the service producing telemetry data. These attributes are attached to all spans and logs exported from Relevance AI.
 
@@ -434,7 +434,7 @@ This attribute is applied to all spans - `chat`, `invoke_agent`, `multi_agent_sy
 }
 ```
 
-### Base Attributes
+### Base attributes
 
 Included on all spans:
 
@@ -445,7 +445,7 @@ Included on all spans:
 | `relevance_ai.user_id` | string | No | User ID that triggered the run |
 | `relevance_ai.user_email` | string | No | Email of the user |
 
-### Span Properties
+### Span properties
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -459,7 +459,7 @@ Included on all spans:
 | `attributes` | array | Key-value pairs with span details |
 | `status.code` | int | 1 = OK, 2 = ERROR |
 
-### Trace Hierarchy
+### Trace hierarchy
 
 Spans share `traceId` and link via `parentSpanId`:
 
@@ -472,7 +472,7 @@ multi_agent_system_trigger
         └── chat
 ```
 
-### Supported Spans
+### Supported spans
 
 ### `invoke_agent`
 
@@ -564,7 +564,7 @@ Records a condition node evaluation in a workforce.
 
 ---
 
-## Attribute Value Types
+## Attribute value types
 
 | Type | JSON Format |
 | --- | --- |
@@ -583,12 +583,12 @@ Records a condition node evaluation in a workforce.
 
 - [What is OpenTelemetry?](https://opentelemetry.io/docs/what-is-opentelemetry/) - Official introduction to OTEL concepts
 
-### Compatible Observability Platforms
+### Compatible observability platforms
 
 OTEL is supported by most major observability platforms. See the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for a full list of compatible vendors and integrations.
 
 For a detailed example of ingesting OTEL data, see [Honeycomb's OpenTelemetry guide](https://docs.honeycomb.io/send-data/opentelemetry/).
 
-### Querying OTEL Data Directly
+### Querying OTEL data directly
 
 OTEL JSON files in S3 can be queried directly using SQL tools like [AWS Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html).

--- a/enterprise/streaming-events.mdx
+++ b/enterprise/streaming-events.mdx
@@ -23,7 +23,7 @@ You don't need to run an OTEL collector to use this feature. Events are delivere
 
 <Note>Enterprise customers can enable PII redaction to automatically protect sensitive information in logs. Contact your Account Manager to learn more.</Note>
 
-<Note>**S3 is currently the only supported destination**. Support for direct OTEL collector endpoints is on our roadmap.</Note>
+<Note>S3 is currently the only supported destination. Support for direct OTEL collector endpoints is on our roadmap.</Note>
 
 <Note>Because events are delivered to your own bucket, you control their retention through your bucket's lifecycle policy. On the Relevance side, telemetry only passes through a temporary staging bucket that is automatically purged after 30 days. This is independent of the [Data Retention](/enterprise/data-retention) policy, which governs platform data such as conversations, tool runs, and versions.</Note>
 


### PR DESCRIPTION
## Summary

Documents three Enterprise security topics raised in a customer thread, slotting each into its existing canonical page. Every claim was verified against the platform code (`relevance-api-node`) before writing.

- **Prompt injection detection** — new Enterprise section on the Event Streaming (OpenTelemetry) page. Org-level, enabled by the Relevance team, requires event streaming. Surfaces as `relevance_ai.prompt_injection.detected` / `.confidence` attributes on the `invoke_agent` span (added to that span's attribute table). Documented as detect-and-log only — no block/rewrite behavior is claimed, matching the code.
- **Telemetry retention** — clarifies on both the Data Retention and Event Streaming pages that delivered OTEL telemetry retention is governed by the customer's own S3 bucket lifecycle, while Relevance's internal staging bucket has a fixed 30-day expiry. This is separate from the configurable Data Retention policy (conversations, tool runs, versions).
- **Visual Data Masking export correction** — the page previously claimed exports are fully unmasked. Corrected to note that CSV conversation export masks the agent name ("Run By") column when Visual Data Masking is enabled, while message bodies remain unmasked. Fixed in both the "What isn't masked" list and the export FAQ.
- **Security overview** — the prompt injection protection note now links to the new detection section.

## Files

- `enterprise/streaming-events.mdx` — new prompt injection detection section, `invoke_agent` attributes, overview retention note
- `enterprise/data-retention.mdx` — staging/customer-bucket retention detail in two spots
- `build/agents/build-your-agent/agent-settings/visual-data-masking.mdx` — export masking correction (list + FAQ)
- `admin/security.mdx` — link to the new detection section

## Verification

- All claims confirmed against code with `file:line` evidence (org-level `prompt_injection_mode` config, `customer_otel.enabled` prerequisite, 30-day staging bucket lifecycle in Terraform, agent-level CSV export masking).
- `mint broken-links` reports no broken links introduced by this PR.
- Previewed locally on the Event Streaming, Data Retention, Visual Data Masking, and Security pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)