### PR TITLE
docs: remove old pricing-model references

### DIFF
--- a/admin/subscriptions/new-pricing.mdx
+++ b/admin/subscriptions/new-pricing.mdx
@@ -4,6 +4,10 @@ sidebarTitle: "Pricing and packaging changes"
 description: "Subscriptions in Relevance AI are changing, starting 8 September 2025"
 ---
 
+<Info>
+  All customers have now been transitioned to our new pricing model. This page is retained for reference.
+</Info>
+
 As of 8 September 2025, we're changing our pricing model. We're splitting credits into Actions (what your agents do) and Vendor Credits (AI model costs). We will not charge a markup on Vendor Credits -- we pass through exact costs. Credits will roll over indefinitely while you're subscribed, and you can bring your own API keys anytime to bypass Vendor Credits entirely. We've also sunset the Business plan.
 
 Some customers will still be on our old plans, and will be gradually grandfathered into our new pricing model. As a result, to use this page, please navigate to the tab for your plan.

--- a/admin/subscriptions/plans.mdx
+++ b/admin/subscriptions/plans.mdx
@@ -4,408 +4,199 @@ sidebarTitle: "Plans and credits"
 description: "Understand different plans at Relevance AI, and learn how to manage your subscription"
 ---
 
+## Understanding Actions
+
+An Action is a single run of a Tool. Each time a tool runs, it counts as an action — whether it's a simple task like sending one email or running a complex workflow with many steps.
+
+Actions are charged when you run a Tool, or when your Agent / Workforce runs a Tool. If the Tool fails, this will still count as one Action.
+
+## Understanding Vendor Credits
+
+Vendor Credits are the cost of running the AI model. This is the cost of the LLM, and the cost of the tools you use.
+
+Pay only for the LLMs you use, with no markup, and credits that never expire while subscribed.
+
+To bypass Vendor Credits entirely, you can bring your own API keys. This is only available on our paid plans and is not available to free users.
+
+## Purchasing additional Actions and Vendor Credits
+
+If you have a paid plan, you can purchase extra Actions and Vendor Credits to use before your next renewal if you run out.
+
+Both Action top-ups and Vendor Credit top-ups roll over, so you won't lose them at renewal. Action top-ups roll over to your next billing cycle, and Vendor Credit top-ups roll over indefinitely while you're subscribed.
+
+### Pricing for top-ups
+
+- **Actions:** $80 USD per 1,000 Actions
+- **Vendor Credits:** $20 USD per 10,000 Vendor Credits
+
+### How to purchase additional Actions and Vendor Credits
+
+<div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
+<iframe src="https://app.supademo.com/embed/cmkc1sycp387dke4x4u2mkeo5" frameBorder="0" title="How to purchase additional Actions and Vendor Credits" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
+</div>
+
+<Info>
+  You'll need to be an Organization admin to purchase additional Actions and Vendor Credits.
+</Info>
+
+To purchase additional Actions and Vendor Credits:
+
+1. Click the Credit & Action Counter in the bottom left of the home screen
+2. In the top right of the modal, click the **Buy credits** button
+3. This will take you to a page where you can buy both Vendor Credits and Actions
+4. Enter the amount of Vendor Credits and Actions you want to purchase:
+   - Vendor Credits must be in increments of 10,000
+   - Actions must be in increments of 1,000
+5. Click **Next**
+6. Proceed to enter your payment information
+
+## Monitoring Actions and Vendor Credits usage
+
+<Info>
+  You can also set usage alerts to receive email notifications when your credit and action usage reaches a specified limit. [Learn more about usage alerts](/admin/project-management/usage-alerts).
+</Info>
+
+### At an Organization level
+
+To check your Actions and Vendor Credits consumption at an Organization level:
+
+1. Click 'Settings' in the sidebar
+2. Navigate to Plan & Billing
+
 <Warning>
-  As of 1 September 2025, we're changing our pricing model. We're splitting credits into Actions (what your agents do) and Vendor Credits (AI model costs). We will not charge a markup on Vendor Credits -- we pass through exact costs. Credits will roll over indefinitely while you're subscribed, and you can bring your own API keys anytime to bypass Vendor Credits entirely. We've also sunset the Business plan.
-
-  Some customers will still be on our old plans, and will be gradually grandfathered into our new pricing model. As a result, to use this page, please navigate to the tab for your plan.
-
-  If you're on old billing, you'll only see **credits** in the platform. If you're on new billing, you'll see **Actions** and **Vendor Credits** in the platform.
-
-  To read a full breakdown of all the changes, you can read our FAQs [here](/admin/subscriptions/new-pricing).
+  You'll only have access to this section if you are an admin of your Organization.
 </Warning>
 
-<Tabs>
-  <Tab title="New billing (Actions and Vendor Credits)">
-    ## Understanding Actions
+![Marketing image for plan and billing](/images/new-plan-billing.png)
 
-    An Action is a single run of a Tool. Each time a tool runs, it counts as an action — whether it's a simple task like sending one email or running a complex workflow with many steps.
+From this page, you will be able to see credit usage across your entire Organization, and view this by Agent or see a detailed view of your credit expenses.
 
-    Actions are charged when you run a Tool, or when your Agent / Workforce runs a Tool. If the Tool fails, this will still count as one Action.
+### At an individual Agent level
 
-    ## Understanding Vendor Credits
+You can also see how many Actions and Vendor Credits your Agent used, broken down by each Tool and your Agent's LLM cost. 
 
-    Vendor Credits are the cost of running the AI model. This is the cost of the LLM, and the cost of the tools you use.
+<div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
+<iframe src="https://app.supademo.com/embed/cmdy9kmsa8eo39f96j64ckfzb" frameBorder="0" title="How to view the credit usage of an Agent run" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
+</div>
 
-    Pay only for the LLMs you use, with no markup, and credits that never expire while subscribed.
+1. First, access the run of your Agent you want to view credits on, on the Run screen
+2. Click the number next to 'Credits used'
+3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
 
-    To bypass Vendor Credits entirely, you can bring your own API keys. This is only available on our paid plans and is not available to free users.
+### How many Vendor Credits and Actions do I have left?
 
-    ## Purchasing additional Actions and Vendor Credits
+<img
+  src="/images/new-credits-counter.png"
+  alt="Image showing the credits counter in Relevance AI, and explaining that the counter shows the number of credits remaining over the number of credits in your plan per month / year"
+  className="mx-auto"
+/>
 
-    If you have a paid plan, you can purchase extra Actions and Vendor Credits to use before your next renewal if you run out.
+You can view how many Actions and Vendor Credits you have left in the bottom left of Relevance AI. The credits counter will show you a total of the **number of Actions and Vendor Credits you have left remaining** over the **number of Actions and Vendor Credits you receive in your plan per month / year**.
 
-    Both Action top-ups and Vendor Credit top-ups roll over, so you won't lose them at renewal. Action top-ups roll over to your next billing cycle, and Vendor Credit top-ups roll over indefinitely while you're subscribed.
+The color of the counter also indicates how many credits you have remaining based on how many you have in your billing period. If your counter is green, this means you're in a good position\! If the counter turns red, you should consider adding more credits if you think you're going to run out before your next renewal, or consider upgrading to a higher plan in the future.
 
-    ### Pricing for top-ups
+For example, in the image above, this user is on a Pro plan, billed monthly. They currently receive 2500 Actions per month, and 3000 Vendor Credits. They have 1267 Actions and 1995 Vendor Credits left.
 
-    - **Actions:** $80 USD per 1,000 Actions
-    - **Vendor Credits:** $20 USD per 10,000 Vendor Credits
+## Monitoring concurrency usage
 
-    ### How to purchase additional Actions and Vendor Credits
+Concurrency is a system capacity metric — it measures how many tasks are running simultaneously across your Organization, not how many credits or actions you consume. Each subscription tier has a specific concurrent task limit. When you reach this limit, additional tasks are queued until capacity becomes available.
 
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmkc1sycp387dke4x4u2mkeo5" frameBorder="0" title="How to purchase additional Actions and Vendor Credits" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-    </div>
+<Note>
+  For detailed information about concurrent task limits for each subscription tier, see the [System Quotas](/admin/system-limits#concurrent-tasks) page.
+</Note>
 
-    <Info>
-      You'll need to be an Organization admin to purchase additional Actions and Vendor Credits.
-    </Info>
+A time-series area chart displays your Organization's concurrency usage over time, helping you identify peak usage periods and determine when to upgrade for increased capacity. You can view this same chart in two places:
 
-    To purchase additional Actions and Vendor Credits:
+- On the **Plan & Billing** page: click 'Settings' in the sidebar, then open Plan & Billing.
+- On the **Analytics** page, where the same chart shows organization-wide concurrency data, so you can correlate agent activity with overall concurrency patterns.
 
-    1. Click the Credit & Action Counter in the bottom left of the home screen
-    2. In the top right of the modal, click the **Buy credits** button
-    3. This will take you to a page where you can buy both Vendor Credits and Actions
-    4. Enter the amount of Vendor Credits and Actions you want to purchase:
-       - Vendor Credits must be in increments of 10,000
-       - Actions must be in increments of 1,000
-    5. Click **Next**
-    6. Proceed to enter your payment information
+## Credit allocation and reset
 
-    ## Monitoring Actions and Vendor Credits usage
+For paid plans, Vendor Credits and Actions will be topped up at your next renewal date.
 
-    <Info>
-      You can also set usage alerts to receive email notifications when your credit and action usage reaches a specified limit. [Learn more about usage alerts](/admin/project-management/usage-alerts).
-    </Info>
+**Vendor Credits rollover:** All Vendor Credits roll over indefinitely while you're subscribed. This includes both the Vendor Credits included in your plan and any Vendor Credit top-ups you purchase. You'll never lose unused Vendor Credits as long as you maintain an active subscription.
 
-    ### At an Organization level
+**Actions rollover:** Actions included in your plan will reset to your plan's default amount at each renewal. However, any Action top-ups you purchase will roll over to your next billing cycle. This means purchased Action top-ups carry forward, but your base plan Actions reset.
 
-    To check your Actions and Vendor Credits consumption at an Organization level:
+<Note>
+  This only applies to Free, Pro and Team plans. Enterprise customers should contact their Account Manager to check the rollover behavior for their Enterprise Organization.
+</Note>
 
-    1. Click 'Settings' in the sidebar
-    2. Navigate to Plan & Billing
+For free users, you will be given 1000 Vendor Credits when you sign up to Relevance AI, and 200 Actions a month. To access more Vendor Credits, you'll need to upgrade to a subscription.
 
-    <Warning>
-      You'll only have access to this section if you are an admin of your Organization.
-    </Warning>
+## Paying for plans
 
-    ![Marketing image for plan and billing](/images/new-plan-billing.png)
+At this time, we only offer the ability to pay for subscriptions using a credit card. We do not support debit cards at this time.
 
-    From this page, you will be able to see credit usage across your entire Organization, and view this by Agent or see a detailed view of your credit expenses.
+## Managing and updating payment methods
 
-    ### At an individual Agent level
+<Info>
+  You'll need to be an Organization admin to manage payment methods.
+</Info>
 
-    You can also see how many Actions and Vendor Credits your Agent used, broken down by each Tool and your Agent's LLM cost. 
+To add, update, or remove payment methods:
 
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmdy9kmsa8eo39f96j64ckfzb" frameBorder="0" title="How to view the credit usage of an Agent run" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-    </div>
+1. Click the **Manage plan / credits counter** section at the bottom left of the dashboard
+2. Click **Manage payment methods**
+3. From here, you can add a new card, update an existing payment method, or remove old payment methods
 
-    1. First, access the run of your Agent you want to view credits on, on the Run screen
-    2. Click the number next to 'Credits used'
-    3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
+## Cancelling your subscription
+You can easily cancel your subscription if you are an organization admin by following this tutorial:
 
-    ### How many Vendor Credits and Actions do I have left?
+<div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
+<iframe src="https://app.supademo.com/embed/cmf9ojd725f8039ozlcbgs7eo" frameBorder="0" title="How to cancel your subscription in Relevance AI" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
+</div>
 
-    <img
-      src="/images/new-credits-counter.png"
-      alt="Image showing the credits counter in Relevance AI, and explaining that the counter shows the number of credits remaining over the number of credits in your plan per month / year"
-      className="mx-auto"
-    />
+1. Click 'Manage plan' at the bottom of the platform
+2. Click 'Cancel subscription'
+3. On the pop-up that opens, click 'Cancel subscription' _again_ to make sure the cancellation goes through
+4. You should then be directed to a pop-up confirming that you've cancelled successfully
 
-    You can view how many Actions and Vendor Credits you have left in the bottom left of Relevance AI. The credits counter will show you a total of the **number of Actions and Vendor Credits you have left remaining** over the **number of Actions and Vendor Credits you receive in your plan per month / year**.
+## Invoices and receipts
 
-    The color of the counter also indicates how many credits you have remaining based on how many you have in your billing period. If your counter is green, this means you're in a good position\! If the counter turns red, you should consider adding more credits if you think you're going to run out before your next renewal, or consider upgrading to a higher plan in the future.
+Invoices and receipts for payment will be sent to the user at your company who purchased the subscription / credits at the time of purchase. You'll also be sent a receipt / invoice at every renewal.
 
-    For example, in the image above, this user is on a Pro plan, billed monthly. They currently receive 2500 Actions per month, and 3000 Vendor Credits. They have 1267 Actions and 1995 Vendor Credits left.
+To find your invoices and receipts in the platform:
 
-    ## Monitoring concurrency usage
+1. Click 'Settings' while logged into Relevance AI
+2. Click 'Invoice management'
+3. From here, you can view and download your invoices and receipts
 
-    Concurrency is a system capacity metric — it measures how many tasks are running simultaneously across your Organization, not how many credits or actions you consume. Each subscription tier has a specific concurrent task limit. When you reach this limit, additional tasks are queued until capacity becomes available.
+<Warning>
+  You'll only have access to Invoice management if you are an admin of your Organization.
+</Warning>
 
-    <Note>
-      For detailed information about concurrent task limits for each subscription tier, see the [System Quotas](/admin/system-limits#concurrent-tasks) page.
-    </Note>
+### Organization name on invoices
 
-    A time-series area chart displays your Organization's concurrency usage over time, helping you identify peak usage periods and determine when to upgrade for increased capacity. You can view this same chart in two places:
+The organization name that appears on your invoices is the same as your organization name in Relevance AI. If you need to change the organization name on your invoices, you can [update your organization name](/admin/project-management/change-project-and-org-name) in the platform.
 
-    - On the **Plan & Billing** page: click 'Settings' in the sidebar, then open Plan & Billing.
-    - On the **Analytics** page, where the same chart shows organization-wide concurrency data, so you can correlate agent activity with overall concurrency patterns.
+### Updating other invoice details
 
-    ## Credit allocation and reset
+For changes to other invoice details such as billing addresses or tax information, [contact our support team](/get-started/support). The easiest way to do this is to forward your latest invoice along with the details you'd like updated.
 
-    For paid plans, Vendor Credits and Actions will be topped up at your next renewal date.
+## Frequently asked questions (FAQs)
 
-    **Vendor Credits rollover:** All Vendor Credits roll over indefinitely while you're subscribed. This includes both the Vendor Credits included in your plan and any Vendor Credit top-ups you purchase. You'll never lose unused Vendor Credits as long as you maintain an active subscription.
+<AccordionGroup>
+  <Accordion title="What rolls over and what resets at renewal?">
+    Understanding what carries over to your next billing cycle:
 
-    **Actions rollover:** Actions included in your plan will reset to your plan's default amount at each renewal. However, any Action top-ups you purchase will roll over to your next billing cycle. This means purchased Action top-ups carry forward, but your base plan Actions reset.
+    Vendor Credits included in your plan and any Vendor Credit top-ups you purchase will roll over indefinitely while you're subscribed. You'll never lose unused Vendor Credits.
 
-    <Note>
-      This only applies to Free, Pro and Team plans. Enterprise customers should contact their Account Manager to check the rollover behavior for their Enterprise Organization.
-    </Note>
+    Actions included in your plan will reset to your plan's default amount at renewal. However, any Action top-ups you purchase will roll over to your next billing cycle.
 
-    For free users, you will be given 1000 Vendor Credits when you sign up to Relevance AI, and 200 Actions a month. To access more Vendor Credits, you'll need to upgrade to a subscription.
+    This means if you purchase additional Actions or Vendor Credits as top-ups, those will carry forward, but your base plan Actions will reset to the standard amount for your subscription tier.
+  </Accordion>
+  <Accordion title="Can I purchase additional Actions and Vendor Credits if I run out?">
+    Yes! You can purchase additional Actions and Vendor Credits if you have a subscription.
 
-    ## Paying for plans
+    Actions are priced at $80 USD per 1,000 Actions, and Vendor Credits are priced at $20 USD per 10,000 Vendor Credits.
 
-    At this time, we only offer the ability to pay for subscriptions using a credit card. We do not support debit cards at this time.
-
-    ## Managing and updating payment methods
-
-    <Info>
-      You'll need to be an Organization admin to manage payment methods.
-    </Info>
-
-    To add, update, or remove payment methods:
-
-    1. Click the **Manage plan / credits counter** section at the bottom left of the dashboard
-    2. Click **Manage payment methods**
-    3. From here, you can add a new card, update an existing payment method, or remove old payment methods
-
-    ## Cancelling your subscription
-    You can easily cancel your subscription if you are an organization admin by following this tutorial:
-    
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmf9ojd725f8039ozlcbgs7eo" frameBorder="0" title="How to cancel your subscription in Relevance AI" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-    </div>
-    
-    1. Click 'Manage plan' at the bottom of the platform
-    2. Click 'Cancel subscription'
-    3. On the pop-up that opens, click 'Cancel subscription' _again_ to make sure the cancellation goes through
-    4. You should then be directed to a pop-up confirming that you've cancelled successfully
-
-    ## Invoices and receipts
-
-    Invoices and receipts for payment will be sent to the user at your company who purchased the subscription / credits at the time of purchase. You'll also be sent a receipt / invoice at every renewal.
-
-    To find your invoices and receipts in the platform:
-
-    1. Click 'Settings' while logged into Relevance AI
-    2. Click 'Invoice management'
-    3. From here, you can view and download your invoices and receipts
-
-    <Warning>
-      You'll only have access to Invoice management if you are an admin of your Organization.
-    </Warning>
-
-    ### Organization name on invoices
-
-    The organization name that appears on your invoices is the same as your organization name in Relevance AI. If you need to change the organization name on your invoices, you can [update your organization name](/admin/project-management/change-project-and-org-name) in the platform.
-
-    ### Updating other invoice details
-
-    For changes to other invoice details such as billing addresses or tax information, [contact our support team](/get-started/support). The easiest way to do this is to forward your latest invoice along with the details you'd like updated.
-
-    ## Frequently asked questions (FAQs)
-
-    <AccordionGroup>
-      <Accordion title="What rolls over and what resets at renewal?">
-        Understanding what carries over to your next billing cycle:
-
-        Vendor Credits included in your plan and any Vendor Credit top-ups you purchase will roll over indefinitely while you're subscribed. You'll never lose unused Vendor Credits.
-
-        Actions included in your plan will reset to your plan's default amount at renewal. However, any Action top-ups you purchase will roll over to your next billing cycle.
-
-        This means if you purchase additional Actions or Vendor Credits as top-ups, those will carry forward, but your base plan Actions will reset to the standard amount for your subscription tier.
-      </Accordion>
-      <Accordion title="Can I purchase additional Actions and Vendor Credits if I run out?">
-        Yes! You can purchase additional Actions and Vendor Credits if you have a subscription.
-
-        Actions are priced at $80 USD per 1,000 Actions, and Vendor Credits are priced at $20 USD per 10,000 Vendor Credits.
-
-        Both Action top-ups and Vendor Credit top-ups roll over. This is different from your plan's included Actions, which reset at renewal. Purchased Action top-ups will carry forward to your next billing cycle, and Vendor Credit top-ups roll over indefinitely.
-      </Accordion>
-      <Accordion title="Can I bring my own API keys to bypass Vendor Credits?">
-        Yes! You can bring your own API keys to bypass Vendor Credits entirely. This is only available on our paid plans and is not available to free users.
-      </Accordion>
-    </AccordionGroup>
-  </Tab>
-  <Tab title="Old billing (Credits)">
-    ## Understanding credits
-
-    Relevance provides a variety of plans enabling you to choose the best option according to your needs.
-
-    Each plan supports a certain number of users, credits per execution, specific data size and certain Large Language Models.
-
-    Below is a brief overview of the available plans and their specification.
-
-    For the most updated list, please visit Relevance AI's [pricing](/get-started/pricing) page.
-
-    <Note>
-      It is always possible to upgrade or downgrade your plan based on your usage and workload\!
-    </Note>
-
-    ### Base credits costs
-
-    The base cost for running any tool or agent is 4 credits. However, this cost varies depending on your plan.
-
-    | Plan       | Credits per run |
-    | ---------- | --------------- |
-    | Free       | 4               |
-    | Pro        | 4               |
-    | Team       | 3               |
-    | Business   | 2               |
-    | Enterprise | 2               |
-
-    ### How many credits do I have left?
-
-    <img
-      src="/images/credit-counter-explanation.png"
-      alt="Image showing the credits counter in Relevance AI, and explaining that the counter shows the number of credits remaining over the number of credits in your plan per month / year"
-      className="mx-auto"
-    />
-
-    You can view how many credits you have left in the bottom left of Relevance AI. The credits counter will show you a total of the **number of credits you have left remaining** over the **number of credits you receive in your plan per month / year** (or day if you're a free user).
-
-    The color of the counter also indicates how many credits you have remaining based on how many you have in your billing period. If your counter is green, this means you're in a good position\! If the counter turns red, you should consider adding more credits if you think you're going to run out before your next renewal, or consider upgrading to a higher plan in the future.
-
-    For example, in the image above, this user is on a Team plan, billed monthly. They currently receive 100,000 credits per month, and have 75,500 left. They have 14 days left, and are in a good position to continue using Relevance AI until their next renewal period.
-
-    ### What affects total credit cost?
-
-    Your total credit consumption depends on several factors:
-
-    #### Tool steps
-
-    - When using integrations without your own API key, additional credits are charged since you're using our API keys.
-    - If you provide your own API key, no additional credits are charged for integrations.
-
-    #### Large Language Model selection
-
-    - Different models have different credit costs.
-    - Specific costs can be found in the `model` selector within the platform.
-
-    <Frame>
-      ![The model selector in Relevance AI showing available LLMs and their credit costs](/images/model-selector.png)
-    </Frame>
-
-    #### Knowledge sync
-
-    - Knowledge is our RAG (Retrieval-Augmented Generation) solution that enables you to provide additional context to your agents and tools.
-    - When syncing knowledge, your data is vectorized to enable search capabilities.
-    - Knowledge sync operations have the same base credit cost as a tool run.
-
-    ### Credit allocation and reset
-
-    #### Reset schedule
-
-    - **Free Plan:** Credits reset daily at midnight, Sydney time (AEST / AEDT)
-    - **Paid Plans:** Credits reset at your next renewal date
-
-    ### Purchasing additional credits
-
-    If you have a paid plan, you can purchase extra credits to use before your next renewal if you run out.
-
-    If you purchase these extra credits, **please note that these do not roll over to the next billing cycle**. You will sacrifice your credits at your next renewal date, and your credits will reset to your plan's default amount.
-
-    The minimum amount of credits you can purchase is 10000 credits (\$20 USD).
-
-    ### Monitoring credit usage
-
-    #### At an Organization level
-
-    To check your credit consumption at an Organization level:
-
-    1. Click 'Settings' in the sidebar
-    2. Navigate to Plan & Billing
-
-    <Warning>
-      You'll only have access to this section if you are an admin of your Organization.
-    </Warning>
-
-    ![Marketing image for plan and billing](/images/credits_plan_billing.png)
-
-    From this page, you will be able to see credit usage across your entire Organization, and view this by Agent or see a detailed view of your credit expenses.
-
-    #### At an individual Agent level
-
-    You can also see how many credits your Agent used, broken down by each Tool and your Agent's LLM cost. 
-
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmdy9kmsa8eo39f96j64ckfzb" frameBorder="0" title="How to view the credit usage of an Agent run" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-    </div>
-
-    1. First, access the run of your Agent you want to view credits on, on the Run screen
-    2. Click the number next to 'Credits used'
-    3. This will open a pop-up that will show you how much each Tool cost, as well as your Agent LLM cost and the base run cost
-
-    ## Monitoring concurrency usage
-
-    Concurrency is a system capacity metric — it measures how many tasks are running simultaneously across your Organization, not how many credits you consume. Each subscription tier has a specific concurrent task limit. When you reach this limit, additional tasks are queued until capacity becomes available.
-
-    <Note>
-      For detailed information about concurrent task limits for each subscription tier, see the [System Quotas](/admin/system-limits#concurrent-tasks) page.
-    </Note>
-
-    A time-series area chart displays your Organization's concurrency usage over time, helping you identify peak usage periods and determine when to upgrade for increased capacity. You can view this same chart in two places:
-
-    - On the **Plan & Billing** page: click 'Settings' in the sidebar, then open Plan & Billing.
-    - On the **Analytics** page, where the same chart shows organization-wide concurrency data, so you can correlate agent activity with overall concurrency patterns.
-
-    ## Paying for plans
-
-    At this time, we only offer the ability to pay for subscriptions using a credit card. We do not support debit cards at this time.
-
-    ## Managing and updating payment methods
-
-    <Info>
-      You'll need to be an Organization admin to manage payment methods.
-    </Info>
-
-    To add, update, or remove payment methods:
-
-    1. Click the **Manage plan / credits counter** section at the bottom left of the dashboard
-    2. Click **Manage payment methods**
-    3. From here, you can add a new card, update an existing payment method, or remove old payment methods
-
-    ## Cancelling your subscription
-
-    You can cancel your Relevance AI subscription at any time by following this tutorial:
-
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmaypwh9o8hb9ho3rmx2lo1j6" frameBorder="0" title="How to cancel your subscription in Relevance AI" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-
-    </div>
-
-    1. To start, click the 'Manage plan' section at the bottom of the platform while logged into Relevance AI
-    2. Click on 'Cancel subscription'
-    3. On the pop-up that opens, click 'Cancel subscription' _again_ to make sure the cancellation goes through
-    4. You should then be directed to a pop-up confirming that you've cancelled successfully
-
-    If the platform doesn't confirm that you've cancelled successfully, please try again, then **contact support** to ensure that your cancellation has gone through and you will not be billed.
-
-    If the platform has confirmed your cancellation is successful, you do not need to reach out to our support team.
-
-    Once you cancel, you'll still have access to your upgraded features until your next renewal date. You will not have your subscription immediately cancelled, and your latest payment will not be refunded. If you have any further questions about cancellation, please [reach out to our support team](/get-started/support).
-
-    ## Invoices and receipts
-
-    Invoices and receipts for payment will be sent to the user at your company who purchased the subscription / credits at the time of purchase. You'll also be sent a receipt / invoice at every renewal.
-
-    However, if you need to get a new invoice / receipt, or find invoices / receipts in the platform, please follow these steps:
-
-    <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-    <iframe src="https://app.supademo.com/embed/cmayxs0dm8m6qho3rskl47udq" frameBorder="0" title="How to grab your invoices and receipts from Relevance AI" allow="clipboard-write; fullscreen" webkitAllowFullscreen="true" mozAllowFullscreen="true" allowFullscreen style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: '3px solid #5E43CE', borderRadius: '10px' }} />
-
-    </div>
-
-    1. Click 'Settings' while logged into Relevance AI
-    2. Click 'Plan & billing'
-    3. Under 'Payment', click 'View details' (this opens the billing portal for invoice access only — to manage payment methods, see the [Managing and updating payment methods](#managing-and-updating-payment-methods) section above)
-    4. This will open our payment system's page. On this page, scroll down to 'Invoice History' and click the payment you want to get an invoice for
-    5. On the page that opens, click 'Download invoice' or 'Download receipt' based on the document you need
-
-    ### Organization name on invoices
-
-    The organization name that appears on your invoices is the same as your organization name in Relevance AI. If you need to change the organization name on your invoices, you can [update your organization name](/admin/project-management/change-project-and-org-name) in the platform.
-
-    ### Updating other invoice details
-
-    For changes to other invoice details such as billing addresses or tax information, [contact our support team](/get-started/support). The easiest way to do this is to forward your latest invoice along with the details you'd like updated.
-
-    ## Frequently asked questions (FAQs)
-
-    <AccordionGroup>
-      <Accordion title="I've accidentally upgraded with annual billing, but I meant to upgrade with monthly billing. How do I change to monthly billing going forward?">
-        Unfortunately if you change in platform, this change will only be put into place at your next renewal date in a year.
-
-        If you want to change to monthly billing immediately, you'll need to [reach out to our support team](/get-started/support).
-      </Accordion>
-      <Accordion title="I've just renewed but it's showing that I've already used all of my credits?">
-        Check your credit counter to make sure you've read this correctly. Your credits counter will show you **the number of credits you have left to use**, not the number of credits you've used.
-
-        If your counter is showing 10100 credits over 10000, for instance, this means you have 10100 credits left to use in your current billing period, not that you've used 10100 credits. 
-      </Accordion>
-    </AccordionGroup>
-  </Tab>
-</Tabs>
+    Both Action top-ups and Vendor Credit top-ups roll over. This is different from your plan's included Actions, which reset at renewal. Purchased Action top-ups will carry forward to your next billing cycle, and Vendor Credit top-ups roll over indefinitely.
+  </Accordion>
+  <Accordion title="Can I bring my own API keys to bypass Vendor Credits?">
+    Yes! You can bring your own API keys to bypass Vendor Credits entirely. This is only available on our paid plans and is not available to free users.
+  </Accordion>
+  <Accordion title="I'm on old billing with Credits — what happened to the old pricing model?">
+    In September 2025 we moved to a new pricing model that splits Credits into Actions (what your agents do) and Vendor Credits (AI model costs). All customers have now been transitioned to the new pricing model, so you'll see Actions and Vendor Credits in the platform rather than Credits. For a full breakdown of the changes, see our [pricing and packaging changes FAQ](/admin/subscriptions/new-pricing).
+  </Accordion>
+</AccordionGroup>

--- a/admin/subscriptions/spend-controls.mdx
+++ b/admin/subscriptions/spend-controls.mdx
@@ -11,7 +11,7 @@ description: "Configure automatic top-up limits for Actions and Vendor Credits t
 Spend Controls allows you to configure automatic top-up limits for both your Actions and Vendor Credits, ensuring your account never runs out of credits unexpectedly.
 
 <Note>
-  Spend Controls is available to Pro and Team plan users (monthly and annual). You must be on our new pricing model to access this feature. If you're still on the old pricing model with Credits (not Actions and Vendor Credits), you won't have access to Spend Controls yet.
+  Spend Controls is available to Pro and Team plan users (monthly and annual).
 </Note>
 
 ## How to configure spend controls

--- a/build/agents/build-your-agent/agent-triggers/integrations.mdx
+++ b/build/agents/build-your-agent/agent-triggers/integrations.mdx
@@ -10,7 +10,7 @@ For each trigger, connect to the integration using your associated credentials. 
 
 ### Premium Triggers
 
-The Premium triggers below are available on the Pro plan and above. Learn more about our [new pricing](/admin/subscriptions/new-pricing).
+The Premium triggers below are available on the Pro plan and above.
 
 <Columns cols={2}>
   <Card title="LinkedIn" href="/integrations/popular-integrations/linkedin#setting-up-triggers" icon="linkedin">Initiate your AI agents based on specific LinkedIn events</Card>
@@ -32,6 +32,6 @@ External triggers like **Zapier** are configured and managed outside of Relevanc
     Navigate to your agent's Triggers section, select the integration you want to connect, and authenticate with your credentials for that service.
   </Accordion>
   <Accordion title="Are premium triggers included in my plan?">
-    Premium triggers (LinkedIn, WhatsApp, WhatsApp for Business, and Telegram) are available on the Pro plan and above. Check the [pricing page](/admin/subscriptions/new-pricing) for details.
+    Premium triggers (LinkedIn, WhatsApp, WhatsApp for Business, and Telegram) are available on the Pro plan and above.
   </Accordion>
 </AccordionGroup>

--- a/docs.json
+++ b/docs.json
@@ -533,7 +533,6 @@
                 "group": "Subscriptions",
                 "pages": [
                   "admin/subscriptions/plans",
-                  "admin/subscriptions/new-pricing",
                   "admin/subscriptions/spend-controls"
                 ]
               },

--- a/get-started/support.mdx
+++ b/get-started/support.mdx
@@ -95,14 +95,8 @@ While **Free** customers can raise tickets at this time, we do not offer SLAs fo
 
     All interactions are governed by our [Terms & Conditions](https://relevanceai.com/terms-and-conditions). We welcome constructive feedback about our products and services, and we encourage you to share it professionally.
   </Accordion>
-  <Accordion title="I am on the old Business plan, what support and SLAs are available to me?">
-    As a Business customer, if you already have a dedicated Slack channel, you can continue to use it to reach out to support. However, if you request to create a channel, we will not be able to create a channel for you, as the Business plan is in the process of being sunset.
-
-    We offer Enterprise SLAs to Business customers, regardless of whether they reach out to us via Slack, email or chat.
-
-    On your first renewal date on or after 1 December 2025, you'll be moved to the Team plan, and you'll have access to Team SLAs. If you have a dedicated Slack channel, this will be archived. If you wish to continue to have priority support, you will need to upgrade to Enterprise. If you'd like to discuss an upgrade to Enterprise, please reach out to support via your Slack channel or one of the methods listed above.
-
-    To learn more about our pricing changes, you can read our FAQs [here](/admin/subscriptions/new-pricing).
+  <Accordion title="I was on the Business plan — what support and SLAs are available to me?">
+    The Business plan has been sunset, and all Business customers have automatically been moved to the Team plan. If you'd like to retain your dedicated Slack channel, please contact our sales team to discuss an upgrade to Enterprise.
   </Accordion>
   <Accordion title="I emailed a team member / AI Agent at Relevance AI for support and didn't get an answer - how do I get help?">
     Our team members and AI Agents aren't able to help answer questions. Please reach out using one of the methods above and we'll be able to help you with your question or issue!

--- a/get-started/troubleshooting/troubleshooting-agents-not-working.mdx
+++ b/get-started/troubleshooting/troubleshooting-agents-not-working.mdx
@@ -19,10 +19,6 @@ Relevance AI uses two types of consumption:
 - **Actions**: Each time a tool runs, it counts as one action — whether it's a simple task like sending one email or running a complex workflow with many steps
 - **Vendor Credits**: The cost of running the AI model (LLM costs) and the tools you use
 
-<Info>
-  If you're on the new billing model, you'll see both Actions and Vendor Credits. If you're on the old billing model, you'll only see credits.
-</Info>
-
 #### How to check your usage
 
 Learn how to monitor your credit and action usage at both the [organization level](/admin/subscriptions/plans#monitoring-actions-and-vendor-credits-usage) and [individual agent level](/admin/subscriptions/plans#at-an-individual-agent-level).

--- a/integrations/popular-integrations/linkedin.mdx
+++ b/integrations/popular-integrations/linkedin.mdx
@@ -19,7 +19,7 @@ Getting started with the LinkedIn Integration is straightforward:
 
 The LinkedIn Integration offers powerful trigger capabilities that can initiate your AI agents based on specific LinkedIn events. This allows your agents to respond automatically to important network activities.
 
-<Warning>The LinkedIn Trigger is considered a Premium trigger, and is available on the Pro plan (new pricing) and above. If you're on the old Pro plan, you'll gain access to this trigger when you move to the new Pro plan on your first renewal on or after December 1, 2025.</Warning>
+<Warning>The LinkedIn Trigger is a Premium trigger, available on the Pro plan and above.</Warning>
 
 ### Available LinkedIn triggers
 

--- a/integrations/popular-integrations/telegram.mdx
+++ b/integrations/popular-integrations/telegram.mdx
@@ -31,7 +31,7 @@ Setting up the Telegram integration with Relevance AI is straightforward:
 
 The Telegram integration can be configured as a trigger for your AI agents, allowing them to automatically respond when messages are received.
 
-<Warning>The Telegram Trigger is considered a Premium trigger, and is available on the Pro plan (new pricing) and above. If you're on the old Pro plan, you'll gain access to this trigger when you move to the new Pro plan on your first renewal on or after December 1, 2025.</Warning>
+<Warning>The Telegram Trigger is a Premium trigger, available on the Pro plan and above.</Warning>
 
 ### Create a Telegram trigger
 

--- a/integrations/popular-integrations/whatsapp-for-business.mdx
+++ b/integrations/popular-integrations/whatsapp-for-business.mdx
@@ -19,7 +19,7 @@ Setting up the WhatsApp Business integration with Relevance AI is straightforwar
 
 The WhatsApp Business integration allows you to create powerful triggers that automatically activate your AI agents when specific events occur. This enables seamless customer engagement without manual intervention.
 
-<Warning>The Whatsapp for Business Trigger is considered a Premium trigger, and is available on the Pro plan (new pricing) and above. If you're on the old Pro plan, you'll gain access to this trigger when you move to the new Pro plan on your first renewal on or after December 1, 2025.</Warning>
+<Warning>The WhatsApp for Business Trigger is a Premium trigger, available on the Pro plan and above.</Warning>
 
 To set up a WhatsApp trigger:
 

--- a/integrations/popular-integrations/whatsapp.mdx
+++ b/integrations/popular-integrations/whatsapp.mdx
@@ -23,7 +23,7 @@ Connecting your WhatsApp account to Relevance AI is a straightforward process:
 
 WhatsApp Integration can be configured as a trigger for your AI agents, allowing them to automatically respond when messages are received through WhatsApp.
 
-<Warning>The WhatsApp Trigger is considered a Premium trigger, and is available on the Pro plan (new pricing) and above. If you're on the old Pro plan, you'll gain access to this trigger when you move to the new Pro plan on your first renewal on or after December 1, 2025.</Warning>
+<Warning>The WhatsApp Trigger is a Premium trigger, available on the Pro plan and above.</Warning>
 
 <div
   style={{


### PR DESCRIPTION
## Why

All customers are now on the new pricing model (Actions + Vendor Credits). The docs still carried a lot of transitional language written for the September–December 2025 migration window: Credits-only descriptions, the old/new Pro–Team split, the Business-plan sunset timing, and repeated "first renewal on or after 1 December 2025" wording. None of it applies anymore, and one line in particular caused our support agent (Jack) to tell a customer on #11342 to "upgrade to the new Pro plan" — a plan that no longer exists.

This PR strips that language while keeping the historical record intact.

## Changes

### Premium-trigger warnings (4 files)
Simplified the identical `<Warning>` block on each integration page. Before, each told users on the "old Pro plan" they'd gain access "on your first renewal on or after December 1, 2025". Now they just state the gate:
> The [X] Trigger is a Premium trigger, available on the Pro plan and above.

- `integrations/popular-integrations/whatsapp-for-business.mdx` (also fixed "Whatsapp" → "WhatsApp" casing)
- `integrations/popular-integrations/whatsapp.mdx`
- `integrations/popular-integrations/telegram.mdx`
- `integrations/popular-integrations/linkedin.mdx`

### `admin/subscriptions/plans.mdx` — the big one
- Removed the top `<Warning>` banner announcing the 1 September 2025 pricing change and the "navigate to the tab for your plan" instruction.
- Collapsed the `<Tabs>` structure and **deleted the entire "Old billing (Credits)" tab** (base credit costs table, credit-counter explanation, old cancellation/invoice flows, old FAQs).
- Promoted the "New billing (Actions and Vendor Credits)" content to top level. The page is now a single, un-tabbed "Plans and credits" page.
- Added one FAQ accordion for anyone still wondering where Credits went, pointing to the retained pricing-changes page.

### `admin/subscriptions/spend-controls.mdx`
Trimmed the old-pricing caveat from the availability note — it now just says Spend Controls is available to Pro and Team plan users (monthly and annual).

### `get-started/support.mdx`
Rewrote the Business-plan support accordion. It previously walked through the sunset-in-progress and the 1 December 2025 move-to-Team date. It now states the plan has been sunset, all Business customers are on Team, and points to sales for an Enterprise upgrade if they want to keep a dedicated Slack channel.

### `build/agents/build-your-agent/agent-triggers/integrations.mdx`
Removed the two "new pricing" links/phrasing — the Premium-trigger gate is stated plainly without pointing at the pricing-changes page.

### `admin/subscriptions/new-pricing.mdx` + `docs.json`
The pricing-changes FAQ page is **kept live and reachable by URL** as the historical record, but removed from the sidebar nav (`docs.json`). Added an `<Info>` block at the top noting all customers have been transitioned and the page is retained for reference. Its body is otherwise unchanged.

### `get-started/troubleshooting/troubleshooting-agents-not-working.mdx` (not in original plan)
Removed an `<Info>` block that said "If you're on the old billing model, you'll only see credits" — now false. It only existed to explain the old/new split.

## Decisions worth noting
- **Team, not Enterprise**: the rewritten Business accordion says Business customers moved to **Team** (upgrade to Enterprise to keep a dedicated Slack channel). This matches the follow-on logic about retaining priority support.
- **Left untouched**: `changelog/2024.mdx` and `changelog/2025.mdx` (historical record); the Chat-agent "credits per run" cost phrasing in `get-started/chat/*` (separate product surface, out of scope — possible follow-up to reconcile with Actions/Vendor Credits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)